### PR TITLE
we no longer need to add scopes to the source repos.

### DIFF
--- a/docs/adding-a-new-xpi.md
+++ b/docs/adding-a-new-xpi.md
@@ -14,14 +14,6 @@ The files we need are:
 
 though other files may be helpful as well, e.g. `README.md`, `.gitignore`, `eslintrc.js`.
 
-## Enabling taskcluster CI automation
-
-We currently require a patch like [this](https://hg.mozilla.org/ci/ci-configuration/rev/b3ddb3eca07cd6864bc5fe8dcc46980c5420662a) to enable taskcluster CI automation for on-push and pull request in this repo.
-
-We use [phabricator](https://moz-conduit.readthedocs.io/en/latest/phabricator-user.html#) to submit patches for review.
-
-Ideally we can add some sort of regex or wildcard for all future repos underneath the new github organization, and avoid having to write a ci-configuration patch per new repo.
-
 ### Private repos
 
 To enable cloning private repos, uncomment the `github_clone_secret` line in the source repo's [taskcluster/ci/config.yml](https://github.com/mozilla-extensions/xpi-template/blob/f31e31ca2b2baaf9a60cf684c2bd463ce6c97473/taskcluster/ci/config.yml#L20-L21). This will move the artifact generated into `xpi/build/...` rather than `public/build/...`, and you will need Taskcluster scopes to be able to download the build. The logs will remain public for anyone viewing the task, however.

--- a/docs/adding-a-new-xpi.md
+++ b/docs/adding-a-new-xpi.md
@@ -2,7 +2,7 @@
 
 ## Creating the repo
 
-During this testing phase, the test template source repo is https://github.com/mozilla-extensions/xpi-template . At some point we'll move this to a permanent location and set this up as a github template repo.
+First, create a repository under the `mozilla-extensions` github organization. The template source repo is https://github.com/mozilla-extensions/xpi-template .
 
 The files we need are:
 


### PR DESCRIPTION
Because of this commit [1], we should automatically get the proper
taskcluster scopes for any repository under the mozilla-extensions
Github organization.

[1] https://hg.mozilla.org/ci/ci-configuration/rev/1df6f243cc2838b6c2031bb276137df137ad46ae)