### PR TITLE
fix cache prefix

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -23,6 +23,7 @@ jobs:
     release:
         attributes:
             shipping-phase: build
+            code-review: true
         run:
             using: run-task
             cwd: '{checkout}'

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -33,7 +33,7 @@ taskgraph:
             default-repository: https://github.com/escapewindow/test-xpi-public
             default-ref: master
             type: git
-    cached-task-prefix: xpi.xpi-manifest
+    cached-task-prefix: xpi
 
 workers:
     aliases:


### PR DESCRIPTION
Related to the latest scopes issues. It looks like taskgraph and ci-admin want us to use this format index.

Also, I noticed that the `pr-complete` task was firing too soon, so I fixed that as a ridealong.