### PR TITLE
normandy-devtools 1.0.0

### DIFF
--- a/xpi-manifest.yml
+++ b/xpi-manifest.yml
@@ -32,6 +32,6 @@ xpis:
     active: true
     private-repo: false
     artifacts:
-      - web-ext-artifacts/normandy-devtools-1.0.0.zip
+      - web-ext-artifacts/normandy-devtools.zip
     addon-type: privileged
     install-type: yarn

--- a/xpi-manifest.yml
+++ b/xpi-manifest.yml
@@ -32,6 +32,6 @@ xpis:
     active: true
     private-repo: false
     artifacts:
-      - web-ext-artifacts/normandy-devtools-0.8.0.zip
+      - web-ext-artifacts/normandy-devtools-1.0.0.zip
     addon-type: privileged
     install-type: yarn


### PR DESCRIPTION
This should fix the current bustage, but ideally we can remove the version from the filename to make things more deterministic.