### PR TITLE
Bug 1631375 - Add searchengine-devtools settings.

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -39,6 +39,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/remote-settings-devtools
             default-ref: master
             type: git
+        searchenginedevtools:
+            name: "Search Engine Devtools"
+            project-regex: searchengine-devtools$
+            default-repository: https://github.com/mozilla-extensions/searchengine-devtools
+            default-ref: master
+            type: git
     cached-task-prefix: xpi
 
 workers:

--- a/xpi-manifest.yml
+++ b/xpi-manifest.yml
@@ -44,3 +44,12 @@ xpis:
       - web-ext-artifacts/remote-settings-devtools.xpi
     addon-type: privileged
     install-type: yarn
+  - name: searchengine-devtools
+    description: Search Engine Devtools
+    repo-prefix: searchenginedevtools
+    active: true
+    private-repo: false
+    artifacts:
+      - web-ext-artifacts/searchengine-devtools.xpi
+    addon-type: privileged
+    install-type: npm


### PR DESCRIPTION
This adds what I believe are the required settings for searchengine-devtools to be able to use the release generation.