### PR TITLE
set .taskcluster.yml to collaborators; update taskgraph version

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -197,10 +197,9 @@ tasks:
                           features:
                               taskclusterProxy: true
                               chainOfTrust: true
-                          # Note: This task is built server side without the context or tooling that
-                          # exist in tree so we must hard code the hash
-                          image:
-                              mozillareleases/taskgraph:decision-bd477b55732fc5f5d55a78e6162355af8bc81805b415a9ea8dbe42c020f840db
+
+                          image: mozillareleases/taskgraph:decision-21bef1bc0f11e62c7a23384584f9f8f0d96e95eef192e5bb599fc82ba55c81a7@sha256:d29af306b09cd00a63f982e8caeb53dbec7efd7bb3ae64ce3cef9cd889b750e6
+
 
                           maxRunTime: 1800
 

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -2,12 +2,12 @@
 version: 1
 reporting: checks-v1
 policy:
-    pullRequests: public
+    pullRequests: collaborators
 tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 50ab604215b79ded4cfb9565fa8a9165b90bfd59
+              revision: 7dde9ce7740068d7b73218976343a28fc99be847
           trustDomain: xpi
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'


### PR DESCRIPTION
By setting it to collaborators, we only launch CI if a collaborator
opens a PR. Updating the taskgraph version to keep us from falling too
far out of date.