### PR TITLE
Add WebCompat interventions addon

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -81,6 +81,12 @@ taskgraph:
             default-repository: git@github.com:mozilla-extensions/login-study
             default-ref: master
             type: git
+        webcompat:
+            name: "Web Compat"
+            project-regex: webcompat-addon$
+            default-repository: https://github.com/mozilla-extensions/webcompat-addon
+            default-ref: master
+            type: git
 
     cached-task-prefix: xpi
 

--- a/xpi-manifest.yml
+++ b/xpi-manifest.yml
@@ -123,3 +123,12 @@ xpis:
       - web-ext-artifacts/login-study.xpi
     addon-type: privileged
     install-type: yarn
+  - name: webcompat
+    description: Web Compat
+    repo-prefix: webcompat
+    active: true
+    private-repo: false
+    artifacts:
+      - web-ext-artifacts/webcompat.xpi
+    addon-type: system
+    install-type: npm


### PR DESCRIPTION
This adds configurations for the WebCompat addon that has been migrated to the `mozilla-extensions` org