### PR TITLE
Add doh-resolver-usage-study to repo list

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -99,6 +99,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/firefox-voice
             default-ref: prod
             type: git
+        dohresolverusagestudy:
+            name: "DoH Resolver Usage Study"
+            project-regex: doh-resolver-usage-study$
+            default-repository: git@github.com:mozilla-extensions/doh-resolver-usage-study
+            default-ref: master
+            type: git
 
     cached-task-prefix: xpi
 

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -102,7 +102,7 @@ taskgraph:
         dohresolverusagestudy:
             name: "DoH Resolver Usage Study"
             project-regex: doh-resolver-usage-study$
-            default-repository: git@github.com:mozilla-extensions/doh-resolver-usage-study
+            default-repository: https://github.com/mozilla-extensions/doh-resolver-usage-study
             default-ref: master
             type: git
 

--- a/xpi-manifest.yml
+++ b/xpi-manifest.yml
@@ -153,3 +153,12 @@ xpis:
       - web-ext-artifacts/firefox-voice.xpi
     addon-type: privileged
     install-type: yarn
+  - name: doh-resolver-usage-study
+    description: DoH Resolver Usage Study
+    repo-prefix: dohresolverusagestudy
+    active: true
+    private-repo: false
+    artifacts:
+      - web-ext-artifacts/doh-resolver-usage-study.xpi
+    addon-type: privileged
+    install-type: npm


### PR DESCRIPTION
This is a new add-on for a DoH study. Adding to the list as described in https://github.com/mozilla-extensions/xpi-manifest/blob/master/docs/adding-a-new-xpi.md