### PR TITLE
Add dnssec-interference-study to repo list

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -105,6 +105,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/doh-resolver-usage-study
             default-ref: master
             type: git
+        dnssecinterferencestudy:
+            name: "DNSSEC Interference Study"
+            project-regex: dnssec-interference-study$
+            default-repository: https://github.com/mozilla-extensions/dnssec-interference
+            default-ref: master
+            type: git
 
     cached-task-prefix: xpi
 

--- a/xpi-manifest.yml
+++ b/xpi-manifest.yml
@@ -165,3 +165,12 @@ xpis:
       - web-ext-artifacts/doh-resolver-usage-study.xpi
     addon-type: normandy-privileged
     install-type: npm
+  - name: dnssec-interference-study
+    description: DNSSEC Interference Study
+    repo-prefix: dnssecinterferencestudy
+    active: true
+    private-repo: false
+    artifacts:
+      - web-ext-artifacts/dnssec-interference-study.xpi
+    addon-type: normandy-privileged
+    install-type: npm


### PR DESCRIPTION
This PR adds the mozilla-extensions/dnssec-interference repo. The repo contains the source for an upcoming Normandy study's addon.