### PR TITLE
Follow-up renaming Ion Core to Rally Core

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -117,10 +117,10 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/news-disinformation-study
             default-ref: master
             type: git
-        ioncoreaddon:
-            name: "Ion Core Add-on"
-            project-regex: ioncoreaddon$
-            default-repository: https://github.com/mozilla-extensions/ion-core-addon
+        rallycoreaddon:
+            name: "Rally Core Add-on"
+            project-regex: rallycoreaddon$
+            default-repository: https://github.com/mozilla-extensions/rally-core-addon
             default-ref: master
             type: git
         telemetrytestingextension:

--- a/xpi-manifest.yml
+++ b/xpi-manifest.yml
@@ -185,9 +185,9 @@ xpis:
       - web-ext-artifacts/news-disinformation-study.xpi
     addon-type: privileged
     install-type: npm
-  - name: ion-core-addon
-    description: Ion Core Add-on
-    repo-prefix: ioncoreaddon
+  - name: rally-core-addon
+    description: Rally Core Add-on
+    repo-prefix: rallycoreaddon
     active: true
     private-repo: false
     artifacts:


### PR DESCRIPTION
The repository was renamed to rally-core-addon, while the addon id and the name of generated artifact is currently still the same. It will change in the near future.