### PR TITLE
Add webcompat-release-hotfix XPI

### DIFF
--- a/manifests/webcompat-release-hotfix.yml
+++ b/manifests/webcompat-release-hotfix.yml
@@ -1,0 +1,9 @@
+description: Web Compat
+repo-prefix: webcompat
+active: true
+private-repo: false
+branch: release-hotfix
+artifacts:
+  - web-ext-artifacts/webcompat.xpi
+addon-type: system
+install-type: npm


### PR DESCRIPTION
We sometimes (for example right now) need to create an .xpi that only contains specific new interventions for rollout to release users. We usually do not want to roll out the main branch to release, as that may contain additional code changes that would significantly increase our risk, and make testing a lot more complicated.