### PR TITLE
Rename the rally output file

### DIFF
--- a/manifests/rally-core-addon.yml
+++ b/manifests/rally-core-addon.yml
@@ -3,6 +3,6 @@ repo-prefix: rallycoreaddon
 active: true
 private-repo: false
 artifacts:
-  - web-ext-artifacts/ion_core.xpi
+  - web-ext-artifacts/rally_core.xpi
 addon-type: privileged
 install-type: npm


### PR DESCRIPTION
This is a follow up to #92 and to the requested changes on mozilla-rally/core-addon#271

The artifact name was renamed, so we can now change it too. The new name will be picked up by the clone in `mozilla-extension` as soon as we cut a new release.