### PR TITLE
Set the default branch for webcompat.xpi to 'main'

### DIFF
--- a/manifests/webcompat.yml
+++ b/manifests/webcompat.yml
@@ -2,6 +2,7 @@ description: Web Compat
 repo-prefix: webcompat
 active: true
 private-repo: false
+branch: main
 artifacts:
   - web-ext-artifacts/webcompat.xpi
 addon-type: system


### PR DESCRIPTION
We want to move away from the `master` branch. :)

The `main` branch exists, is already set to the default branch in the repo, and has the same branch protections as the `master` branch. The `master` branch will be removed once we're done with the change.