### PR TITLE
Change the Rally repository URL and default ref

### DIFF
--- a/manifests/rally-core-addon.yml
+++ b/manifests/rally-core-addon.yml
@@ -2,6 +2,7 @@ description: Rally Core Add-on
 repo-prefix: rallycoreaddon
 active: true
 private-repo: false
+branch: release
 artifacts:
   - web-ext-artifacts/rally_core.xpi
 addon-type: privileged

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -120,8 +120,8 @@ taskgraph:
         rallycoreaddon:
             name: "Rally Core Add-on"
             project-regex: rallycoreaddon$
-            default-repository: https://github.com/mozilla-extensions/rally-core-addon
-            default-ref: master
+            default-repository: https://github.com/mozilla-rally/rally-core-addon
+            default-ref: release
             type: git
         telemetrytestingextension:
             name: "Telemetry testing extension"


### PR DESCRIPTION
We'll be cutting new releases from the `release` branch, so I changed `default-ref` too. Is that what is that property for?