### PR TITLE
mark bergamot as inactive until we can fix shipit #649

### DIFF
--- a/manifests/bergamot-browser-extension.yml
+++ b/manifests/bergamot-browser-extension.yml
@@ -1,7 +1,7 @@
 ---
 description: Bergamot Browser Extension
 repo-prefix: bergamotbrowserextension
-active: true
+active: false
 private-repo: false
 additional-emails: ["anatal-all@mozilla.com"]
 directory: extension

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -43,7 +43,7 @@ taskgraph:
             name: "Search Engine Devtools"
             project-regex: searchengine-devtools$
             default-repository: https://github.com/mozilla-extensions/searchengine-devtools
-            default-ref: master
+            default-ref: main
             type: git
         httpsupgradestudyv2:
             name: "HTTPS Upgrade Study (v2)"


### PR DESCRIPTION
Shipit probably needs https://github.com/mozilla-releng/shipit/pull/649 to support `directory`.