### PR TITLE
Run taskgraph generation with Python 3

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 7dde9ce7740068d7b73218976343a28fc99be847
+              revision: f807e7d4d50000fac74fd1b0845f5a669dc9e247
           trustDomain: xpi
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
@@ -195,7 +195,7 @@ tasks:
                               taskclusterProxy: true
                               chainOfTrust: true
 
-                          image: mozillareleases/taskgraph:decision-d9fab4448ee5e00b0a29825c3f0609af957279daf102547d715414782710ef06@sha256:79eb469838621168a6364476b96850fc9f2d353686195c010ad078fdcf29568e
+                          image: mozillareleases/taskgraph:decision-e035c4bb24e3a05bcd666518756aa69fac302ed1e73fd39d39cd182fc4470818@sha256:7cfb913bee636f1ab1477a09f8ad746e1f8c68fab0e2a3e1408c985d2ddc27f7
 
 
                           maxRunTime: 1800
@@ -240,6 +240,14 @@ tasks:
                                   type: 'directory'
                                   path: '/builds/worker/artifacts'
                                   expires: {$fromNow: '1 year'}
+                              'public/docker-contexts':
+                                      type: 'directory'
+                                      path: '/builds/worker/checkouts/src/docker-contexts'
+                                      # This needs to be at least the deadline of the
+                                      # decision task + the docker-image task deadlines.
+                                      # It is set to a week to allow for some time for
+                                      # debugging, but they are not useful long-term.
+                                      expires: {$fromNow: '7 day'}
 
                       extra:
                           $merge:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -213,12 +213,12 @@ tasks:
                                 in:
                                     $if: 'tasks_for == "action"'
                                     then: >
-                                        PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                                        PIP_IGNORE_INSTALLED=0 pip3 install --user /builds/worker/checkouts/taskgraph &&
                                         cd /builds/worker/checkouts/src &&
                                         ln -s /builds/worker/artifacts artifacts &&
                                         ~/.local/bin/taskgraph action-callback
                                     else: >
-                                        PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                                        PIP_IGNORE_INSTALLED=0 pip3 install --user /builds/worker/checkouts/taskgraph &&
                                         ln -s /builds/worker/artifacts artifacts &&
                                         ~/.local/bin/taskgraph decision
                                         --pushlog-id='0'

--- a/taskcluster/docker/node/Dockerfile
+++ b/taskcluster/docker/node/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# %ARG           NODE_VERSION
+ARG           NODE_VERSION
 FROM          node:$NODE_VERSION
 MAINTAINER    Aki Sasaki <aki@mozilla.com>
 

--- a/taskcluster/docker/node/build.py
+++ b/taskcluster/docker/node/build.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 import functools
 import glob
@@ -16,7 +15,7 @@ def test_is_subdir(parent_dir, target_dir):
     p1 = Path(os.path.realpath(parent_dir))
     p2 = Path(os.path.realpath(target_dir))
     if p1 not in p2.parents:
-        raise Exception("{} is not under {}!".format(target_dir, parent_dir))
+        raise Exception(f"{target_dir} is not under {parent_dir}!")
 
 
 def test_var_set(varnames):
@@ -24,37 +23,37 @@ def test_var_set(varnames):
     errors = []
     for varname in varnames:
         if varname not in os.environ:
-            errors.append(("error: {} is not set".format(varname)))
+            errors.append(f"error: {varname} is not set")
     if errors:
         print("\n".join(errors))
         sys.exit(1)
 
 
 def run_command(command, **kwargs):
-    print("Running {} ...".format(command))
+    print(f"Running {command} ...")
     subprocess.check_call(command, **kwargs)
 
 
 def get_output(command, **kwargs):
-    print("Getting output from {} ...".format(command))
+    print(f"Getting output from {command} ...")
     return subprocess.check_output(command, **kwargs)
 
 
 def get_package_info():
     if not os.path.exists("package.json"):
-        raise Exception("Can't find package.json in {}!".format(os.getcwd()))
+        raise Exception(f"Can't find package.json in {os.getcwd()}!")
     with open("package.json") as fh:
         contents = json.load(fh)
     return contents
 
 
 def cd(path):
-    print("Changing directory to {} ...".format(path))
+    print(f"Changing directory to {path} ...")
     os.chdir(path)
 
 
 def mkdir(path):
-    print("mkdir {}".format(path))
+    print(f"mkdir {path}")
     os.makedirs(path, exist_ok=True)
 
 
@@ -76,7 +75,7 @@ def main():
     xpi_name = os.environ["XPI_NAME"]
     xpi_type = os.environ.get("XPI_TYPE")
     repo_prefix = os.environ.get("REPO_PREFIX", "xpi")
-    head_repo_env_var = "{}_HEAD_REPOSITORY".format(repo_prefix.upper())
+    head_repo_env_var = f"{repo_prefix.upper()}_HEAD_REPOSITORY"
     test_var_set([head_repo_env_var])
 
     artifact_dir = "/builds/worker/artifacts"
@@ -112,12 +111,12 @@ def main():
     for artifact in xpi_artifacts:
         target_path = os.path.join(artifact_dir, os.path.basename(artifact))
         if target_path in all_paths:
-            raise Exception("{} already exists!".format(target_path))
+            raise Exception(f"{target_path} already exists!")
         all_paths.append(target_path)
         if not os.path.exists(artifact):
-            raise Exception("Missing artifact {}".format(artifact))
+            raise Exception(f"Missing artifact {artifact}")
         test_is_subdir(os.getcwd(), artifact)
-        print("Copying {} to {}".format(artifact, target_path))
+        print(f"Copying {artifact} to {target_path}")
         path = os.path.join(artifact_prefix, os.path.basename(target_path))
         artifact_info = {
             "path": os.path.join(artifact_prefix, os.path.basename(artifact)),

--- a/taskcluster/docker/node/test.py
+++ b/taskcluster/docker/node/test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 import functools
 import hashlib
@@ -14,7 +13,7 @@ def test_is_subdir(parent_dir, target_dir):
     p1 = Path(os.path.realpath(parent_dir))
     p2 = Path(os.path.realpath(target_dir))
     if p1 not in p2.parents:
-        raise Exception("{} is not under {}!".format(target_dir, parent_dir))
+        raise Exception(f"{target_dir} is not under {parent_dir}!")
 
 
 def test_var_set(varnames):
@@ -22,32 +21,32 @@ def test_var_set(varnames):
     errors = []
     for varname in varnames:
         if varname not in os.environ:
-            errors.append(("error: {} is not set".format(varname)))
+            errors.append(f"error: {varname} is not set")
     if errors:
         print("\n".join(errors))
         sys.exit(1)
 
 
 def run_command(command, **kwargs):
-    print("Running {} ...".format(command))
+    print(f"Running {command} ...")
     subprocess.check_call(command, **kwargs)
 
 
 def get_output(command, **kwargs):
-    print("Getting output from {} ...".format(command))
+    print(f"Getting output from {command} ...")
     return subprocess.check_output(command, **kwargs)
 
 
 def get_package_info():
     if not os.path.exists("package.json"):
-        raise Exception("Can't find package.json in {}!".format(os.getcwd()))
+        raise Exception(f"Can't find package.json in {os.getcwd()}!")
     with open("package.json") as fh:
         contents = json.load(fh)
     return contents
 
 
 def cd(path):
-    print("Changing directory to {} ...".format(path))
+    print(f"Changing directory to {path} ...")
     os.chdir(path)
 
 

--- a/taskcluster/xpi_taskgraph/__init__.py
+++ b/taskcluster/xpi_taskgraph/__init__.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from importlib import import_module
 
@@ -27,4 +26,4 @@ def register(graph_config):
 
 def _import_modules(modules):
     for module in modules:
-        import_module(".{}".format(module), package=__name__)
+        import_module(f".{module}", package=__name__)

--- a/taskcluster/xpi_taskgraph/loader/single_dep.py
+++ b/taskcluster/xpi_taskgraph/loader/single_dep.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 

--- a/taskcluster/xpi_taskgraph/parameters.py
+++ b/taskcluster/xpi_taskgraph/parameters.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.parameters import extend_parameters_schema
 from voluptuous import Any, Optional, Required

--- a/taskcluster/xpi_taskgraph/parameters.py
+++ b/taskcluster/xpi_taskgraph/parameters.py
@@ -12,10 +12,10 @@ from voluptuous import Any, Optional, Required
 
 # Please keep this list sorted
 xpi_schema = {
-    Optional("additional_shipit_emails"): Any([basestring], None),
+    Optional("additional_shipit_emails"): Any([str], None),
     Optional("shipping_phase"): Any("build", "promote", "ship", None),
-    Optional("xpi_name"): Any(basestring, None),
-    Optional("xpi_revision"): Any(basestring, None),
+    Optional("xpi_name"): Any(str, None),
+    Optional("xpi_revision"): Any(str, None),
 }
 
 extend_parameters_schema(xpi_schema)

--- a/taskcluster/xpi_taskgraph/release_promotion.py
+++ b/taskcluster/xpi_taskgraph/release_promotion.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.actions.registry import register_callback_action
 

--- a/taskcluster/xpi_taskgraph/routes.py
+++ b/taskcluster/xpi_taskgraph/routes.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import time
 

--- a/taskcluster/xpi_taskgraph/target.py
+++ b/taskcluster/xpi_taskgraph/target.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.target_tasks import _target_task as target_task
 from taskgraph.target_tasks import standard_filter

--- a/taskcluster/xpi_taskgraph/target.py
+++ b/taskcluster/xpi_taskgraph/target.py
@@ -15,7 +15,7 @@ def target_tasks_ship_xpi(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
         return task.attributes.get("shipping-phase") in ("build", "promote", "ship")
 
-    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
+    return [l for l, t in full_task_graph.tasks.items() if filter(t, parameters)]
 
 
 @target_task("promote_xpi")
@@ -25,7 +25,7 @@ def target_tasks_promote_xpi(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
         return task.attributes.get("shipping-phase") in ("build", "promote")
 
-    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
+    return [l for l, t in full_task_graph.tasks.items() if filter(t, parameters)]
 
 
 @target_task("build_xpi")
@@ -35,4 +35,4 @@ def target_tasks_build_xpi(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
         return task.attributes.get("shipping-phase") in ("build",)
 
-    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
+    return [l for l, t in full_task_graph.tasks.items() if filter(t, parameters)]

--- a/taskcluster/xpi_taskgraph/transforms/build.py
+++ b/taskcluster/xpi_taskgraph/transforms/build.py
@@ -6,7 +6,6 @@ Apply some defaults and minor modifications to the jobs defined in the build
 kind.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 from copy import deepcopy
 import os
 

--- a/taskcluster/xpi_taskgraph/transforms/cached.py
+++ b/taskcluster/xpi_taskgraph/transforms/cached.py
@@ -5,7 +5,6 @@
 Build the cached_task digest to prevent rerunning tasks if the code hasn't changed.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import hashlib
 import json
@@ -71,10 +70,10 @@ def build_cache(config, tasks):
                 elif os.path.isfile(resource):
                     digest_data.append(hash_path(path))
                 else:
-                    raise Exception("Unknown resource {}".format(resource))
+                    raise Exception(f"Unknown resource {resource}")
             cache_name = task["name"].replace(":", "-")
             task["cache"] = {
-                "type": "xpi-manifest.v1.{}".format(config.kind),
+                "type": f"xpi-manifest.v1.{config.kind}",
                 "name": cache_name,
                 "digest-data": digest_data,
             }

--- a/taskcluster/xpi_taskgraph/transforms/release_github.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_github.py
@@ -89,7 +89,7 @@ def build_worker_definition(config, jobs):
             {
                 "taskId": {"task-reference": "<release-signing>"},
                 "taskType": "signing",
-                "paths": dep.attributes["xpis"].values(),
+                "paths": list(dep.attributes["xpis"].values()),
             }
         ]
 

--- a/taskcluster/xpi_taskgraph/transforms/release_github.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_github.py
@@ -5,7 +5,6 @@
 Apply some defaults and minor modifications to the jobs defined in the github_release
 kind.
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.config import load_graph_config
 from taskgraph.transforms.base import TransformSequence

--- a/taskcluster/xpi_taskgraph/transforms/release_mark_as_shipped.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_mark_as_shipped.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by

--- a/taskcluster/xpi_taskgraph/transforms/release_notifications.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_notifications.py
@@ -5,7 +5,6 @@
 Add notifications via taskcluster-notify for release tasks
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.keyed_by import evaluate_keyed_by
@@ -40,7 +39,7 @@ def add_notifications(config, jobs):
             job.setdefault("dependencies", {}).update({"signing": dep.label})
         if job.get("attributes", {}).get("shipping-phase") != shipping_phase:
             continue
-        job["label"] = "{}-{}".format(config.kind, shipping_phase)
+        job["label"] = f"{config.kind}-{shipping_phase}"
         xpi_config = manifest[xpi_name]
         xpi_type = xpi_config["addon-type"]
 
@@ -63,7 +62,7 @@ def add_notifications(config, jobs):
         # We only send mail on success to avoid messages like 'blah is in the
         # candidates dir' when cancelling graphs, dummy job failure, etc
         job.setdefault("routes", []).extend(
-            ["notify.email.{}.on-completed".format(email) for email in emails]
+            [f"notify.email.{email}.on-completed" for email in emails]
         )
 
         job.setdefault("extra", {}).update({"notify": {"email": {"subject": subject}}})

--- a/taskcluster/xpi_taskgraph/transforms/signing.py
+++ b/taskcluster/xpi_taskgraph/transforms/signing.py
@@ -6,7 +6,6 @@ Apply some defaults and minor modifications to the jobs defined in the build
 kind.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by

--- a/taskcluster/xpi_taskgraph/transforms/signing.py
+++ b/taskcluster/xpi_taskgraph/transforms/signing.py
@@ -52,7 +52,7 @@ def build_signing_task(config, tasks):
                 )
             )
 
-        paths = dep.attributes["xpis"].values()
+        paths = list(dep.attributes["xpis"].values())
         format = evaluate_keyed_by(
             config.graph_config["scriptworker"]["signing-format"],
             "signing-format",

--- a/taskcluster/xpi_taskgraph/transforms/test.py
+++ b/taskcluster/xpi_taskgraph/transforms/test.py
@@ -6,7 +6,6 @@ Apply some defaults and minor modifications to the jobs defined in the build
 kind.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 from copy import deepcopy
 import json
 import os
@@ -45,7 +44,7 @@ def test_tasks_from_manifest(config, tasks):
             checkout_config["head_rev"] = xpi_revision
         if "docker-image" in xpi_config:
             task["worker"]["docker-image"]["in-tree"] = xpi_config["docker-image"]
-        task["label"] = "test-{}".format(xpi_name)
+        task["label"] = f"test-{xpi_name}"
         if xpi_config.get("private-repo"):
             checkout_config["ssh_secret_name"] = config.graph_config[
                 "github_clone_secret"
@@ -57,7 +56,7 @@ def test_tasks_from_manifest(config, tasks):
         env["ARTIFACT_PREFIX"] = artifact_prefix
         paths = []
         for artifact in xpi_config["artifacts"]:
-            artifact_name = "{}/{}".format(artifact_prefix, os.path.basename(artifact))
+            artifact_name = f"{artifact_prefix}/{os.path.basename(artifact)}"
             paths.append(artifact_name)
         upstreamArtifacts = [{"taskId": "<build>", "paths": paths}]
         env["XPI_UPSTREAM_URLS"] = json.dumps(upstreamArtifacts)

--- a/taskcluster/xpi_taskgraph/worker_types.py
+++ b/taskcluster/xpi_taskgraph/worker_types.py
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
-from six import text_type
-
 from voluptuous import Required
 
 from taskgraph.util.schema import taskref_or_string
@@ -17,18 +13,18 @@ from taskgraph.transforms.task import payload_builder
     schema={
         # the maximum time to run, in seconds
         Required("max-run-time"): int,
-        Required("signing-type"): text_type,
+        Required("signing-type"): str,
         # list of artifact URLs for the artifacts that should be signed
         Required("upstream-artifacts"): [
             {
                 # taskId of the task with the artifact
                 Required("taskId"): taskref_or_string,
                 # type of signing task (for CoT)
-                Required("taskType"): text_type,
+                Required("taskType"): str,
                 # Paths to the artifacts to sign
-                Required("paths"): [text_type],
+                Required("paths"): [str],
                 # Signing formats to use on each of the paths
-                Required("formats"): [text_type],
+                Required("formats"): [str],
             }
         ],
     },
@@ -53,7 +49,7 @@ def build_scriptworker_signing_payload(config, task, task_def):
     )
 
 
-@payload_builder("shipit-shipped", schema={Required("release-name"): text_type})
+@payload_builder("shipit-shipped", schema={Required("release-name"): str})
 def build_push_apk_payload(config, task, task_def):
     worker = task["worker"]
 
@@ -67,17 +63,17 @@ def build_push_apk_payload(config, task, task_def):
         Required("upstream-artifacts"): [
             {
                 Required("taskId"): taskref_or_string,
-                Required("taskType"): text_type,
-                Required("paths"): [text_type],
+                Required("taskType"): str,
+                Required("paths"): [str],
             }
         ],
         Required("artifact-map"): [object],
-        Required("action"): text_type,
-        Required("git-tag"): text_type,
-        Required("git-revision"): text_type,
-        Required("github-project"): text_type,
+        Required("action"): str,
+        Required("git-tag"): str,
+        Required("git-revision"): str,
+        Required("github-project"): str,
         Required("is-prerelease"): bool,
-        Required("release-name"): text_type,
+        Required("release-name"): str,
     },
 )
 def build_github_release_payload(config, task, task_def):

--- a/taskcluster/xpi_taskgraph/xpi_manifest.py
+++ b/taskcluster/xpi_taskgraph/xpi_manifest.py
@@ -28,23 +28,23 @@ MANIFEST_DIR = os.path.join(BASE_DIR, "manifests")
 
 base_schema = Schema(
     {
-        Required("manifest_name"): basestring,
-        Optional("description"): basestring,
-        Required("repo-prefix"): basestring,
-        Optional("directory"): basestring,
+        Required("manifest_name"): str,
+        Optional("description"): str,
+        Required("repo-prefix"): str,
+        Optional("directory"): str,
         Optional("active"): bool,
-        Optional("additional-emails"): [basestring],
+        Optional("additional-emails"): [str],
         Optional("private-repo"): bool,
-        Optional("branch"): basestring,
-        Optional("docker-image"): basestring,
-        Required("artifacts"): [basestring],
+        Optional("branch"): str,
+        Optional("docker-image"): str,
+        Required("artifacts"): [str],
         Required("addon-type"): Any(
             "mozillaonline-privileged", "normandy-privileged", "privileged", "system"
         ),
         Optional("install-type"): Any("npm", "yarn"),
         Optional("enable-github-release"): bool,
-        Optional("release-tag"): basestring,
-        Optional("release-name"): basestring,
+        Optional("release-tag"): str,
+        Optional("release-name"): str,
     }
 )
 

--- a/taskcluster/xpi_taskgraph/xpi_manifest.py
+++ b/taskcluster/xpi_taskgraph/xpi_manifest.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 from copy import deepcopy
 import glob


### PR DESCRIPTION
We're updating consumers of taskgraph to Python 3 so we can drop Python 2 support.

This fixes RELENG-611