### PR TITLE
Allow using the node:lts image as `node-lts-latest`

### DIFF
--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -15,6 +15,10 @@ jobs:
         definition: node
         args:
             NODE_VERSION: "latest"
+    node-lts-latest:
+        definition: node
+        args:
+            NODE_VERSION: "lts"
     node-14:
         definition: node
         args:


### PR DESCRIPTION
As discussed with @jmaher on Slack - using the fixed `14.0.0` version with `node-14` isn't working for us because of a dependency, and using `node:lts` is probably a good balance between having a stable version, not requiring people to manually update the config all the time, and not using `node-latest` because it's too risky.