### PR TITLE
ensure uniqueness of addon+version combination by adding buildid

### DIFF
--- a/taskcluster/docker/node/build.py
+++ b/taskcluster/docker/node/build.py
@@ -72,7 +72,7 @@ def write_package_info(package_info):
 
 def get_buildid():
     now = datetime.utcnow()
-    return now.strftime("%Y%m%d%H%M%S")
+    return now.strftime("%Y%m%d.%H%M%S")
 
 
 def get_buildid_version(version):


### PR DESCRIPTION
The addons team wants to ensure uniqueness of each addon+version
combination; the releng team wants to avoid churn where the development
teams need to bump versions to test a new release-signed addon.

We're following the langpack model by adding the buildid to the version
string, which should hopefully address both teams' concerns.