### PR TITLE
adds npm support for build and test

### DIFF
--- a/manifests/template-example.yml.template
+++ b/manifests/template-example.yml.template
@@ -30,8 +30,9 @@ artifacts:
 #       `mozillaonline-privileged` means Mozilla China add-on.
 #       Required.
 addon-type: privileged
-# enum: `npm` for `npm install` or `yarn` for
-#       `yarn install --frozen-lockfile`. Optional. Defaults to `yarn`.
+# enum: `npm` or `yarn`
+#       sets the package manager used to install dependencies and execute package scripts (e.g. build and test).
+#       Optional. Defaults to `yarn`.
 install-type: npm
 # boolean: true == release artifact to github,
 #          false == manually release artifact

--- a/taskcluster/docker/node/build.py
+++ b/taskcluster/docker/node/build.py
@@ -196,10 +196,10 @@ def main():
 
     if os.environ.get("XPI_INSTALL_TYPE", "yarn") == "yarn":
         run_command(["yarn", "install", "--frozen-lockfile"])
+        run_command(["yarn", "build"])
     else:
         run_command(["npm", "install"])
-
-    run_command(["yarn", "build"])
+        run_command(["npm", "run", "build"])
 
     if 'XPI_ARTIFACTS' in os.environ:
         xpi_artifacts = os.environ["XPI_ARTIFACTS"].split(";")

--- a/taskcluster/docker/node/test.py
+++ b/taskcluster/docker/node/test.py
@@ -75,7 +75,10 @@ def main():
             print("No `test` target in package.json; noop")
 
     for command in commands:
-        run_command(["yarn", command])
+        if os.environ.get("XPI_INSTALL_TYPE", "yarn") == "yarn":
+            run_command(["yarn", command])
+        else:
+            run_command(["npm", "run", command])
 
 
 __name__ == '__main__' and main()

--- a/taskcluster/xpi_taskgraph/transforms/test.py
+++ b/taskcluster/xpi_taskgraph/transforms/test.py
@@ -54,6 +54,8 @@ def test_tasks_from_manifest(config, tasks):
         else:
             artifact_prefix = "public/build"
         env["ARTIFACT_PREFIX"] = artifact_prefix
+        if xpi_config.get("install-type"):
+            env["XPI_INSTALL_TYPE"] = xpi_config["install-type"]
         paths = []
         for artifact in xpi_config["artifacts"]:
             artifact_name = f"{artifact_prefix}/{os.path.basename(artifact)}"


### PR DESCRIPTION
Using the npm/yarn XPI_INSTALL_TYPE flag to determine which packaging tool to use in builds and tests.