### PR TITLE
Upload signed system addon blobs to the mozilla file archive

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -13,6 +13,7 @@ kind-dependencies:
 
 job-template:
     run-on-tasks-for: ["action"]
+    only-for-addon-types: ["system"]
     worker-type: beetmover
     attributes:
         shipping-phase: ship

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: xpi_taskgraph.loader.single_dep:loader
+
+transforms:
+    - xpi_taskgraph.transforms.beetmover:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - release-signing
+
+job-template:
+    run-on-tasks-for: ["action"]
+    worker-type: beetmover
+    attributes:
+        shipping-phase: ship
+    bucket-scope:
+        by-level:
+            '3': "release"
+            default: "dep"

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -142,6 +142,11 @@ workers:
             implementation: scriptworker-github
             os: scriptworker
             worker-type: 'xpi-{level}-github'
+        beetmover:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-beetmover
+            os: scriptworker
+            worker-type: 'xpi-{level}-beetmover'
         signing:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing

--- a/taskcluster/ci/release-mark-as-shipped/kind.yml
+++ b/taskcluster/ci/release-mark-as-shipped/kind.yml
@@ -9,7 +9,7 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    - release-signing
+    - beetmover
 
 job-template:
     name: release-mark-as-shipped

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -76,7 +76,7 @@ def add_beetmover_worker_config(config, tasks):
                             "locale": "multi",
                         },
                     ],
-                    "action-scope": "direct-push-to-bucket",
+                    "action-scope": "push-to-nightly",
                     "bucket-scope": task["bucket-scope"],
                     "release-properties": {
                         "app-name": "xpi",

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -43,18 +43,21 @@ def add_beetmover_worker_config(config, tasks):
             if xpi_addon_type not in task["only-for-addon-types"]:
                 continue
             xpi_version = config.params["version"]
-            xpi_destination = (
-                "pub/system-addons/{xpi_name}/"
-                "{xpi_name}%mozilla.org-{xpi_version}-{build_id}.xpi"
-            ).format(
-                xpi_name=xpi_name,
-                xpi_version=xpi_version,
-                build_id=config.params["moz_build_date"],
-            )
-            xpi_destinations = [xpi_destination]
+            xpi_destinations = []
+            for artifact in xpi_manifest["artifacts"]:
+                artifact_name = basename(artifact)
+                xpi_destination = (
+                    "pub/system-addons/{xpi_name}/"
+                    "{xpi_name}%mozilla.org-{xpi_version}-{build_id}.xpi"
+                ).format(
+                    xpi_name=artifact_name,
+                    xpi_version=xpi_version,
+                    build_id=config.params["moz_build_date"],
+                )
+                xpi_destinations.append(xpi_destination)
             task_label = f"beetmover-{xpi_name}"
             task_description = (
-                "Upload the signed {xpi_name} XPI package to {xpi_destination}"
+                "Upload signed XPI artifacts to pub/system-addons"
             ).format(xpi_name=xpi_name, xpi_destination=xpi_destination)
             resolve_keyed_by(
                 task,

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -51,7 +51,7 @@ def add_beetmover_worker_config(config, tasks):
             xpi_destinations = [xpi_destination]
             task_label = f"beetmover-{xpi_name}"
             task_description = (
-                "Upload the signed {xpi_name} " "XPI package to {xpi_destination}"
+                "Upload the signed {xpi_name} XPI package to {xpi_destination}"
             ).format(xpi_name=xpi_name, xpi_destination=xpi_destination)
             for task in tasks:
                 resolve_keyed_by(

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -1,0 +1,104 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from os.path import basename
+
+from taskgraph.task import Task
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+from voluptuous import Required, Schema
+from xpi_taskgraph.xpi_manifest import get_manifest
+
+transforms = TransformSequence()
+schema = Schema(
+    {
+        Required("primary-dependency"): Task,
+        Required("worker-type"): str,
+        Required("attributes"): dict,
+        Required("bucket-scope"): dict,
+        Required("run-on-tasks-for"): [str],
+    },
+)
+transforms = TransformSequence()
+transforms.add_validate(schema)
+
+
+@transforms.add
+def add_beetmover_worker_config(config, tasks):
+    if (
+        config.params.get("version")
+        and config.params.get("xpi_name")
+        and config.params.get("head_ref")
+        and config.params.get("moz_build_date")
+        and config.params.get("level")
+    ):
+        manifest = get_manifest()
+        xpi_name = config.params["xpi_name"]
+        xpi_manifest = manifest[xpi_name]
+        xpi_addon_type = xpi_manifest["addon-type"]
+        if xpi_addon_type == "system":
+            xpi_version = config.params["version"]
+            xpi_destination = (
+                "pub/system-addons/{xpi_name}/"
+                "{xpi_name}%mozilla.org-{xpi_version}-{build_id}.xpi"
+            ).format(
+                xpi_name=xpi_name,
+                xpi_version=xpi_version,
+                build_id=config.params["moz_build_date"],
+            )
+            xpi_destinations = [xpi_destination]
+            task_label = f"beetmover-{xpi_name}"
+            task_description = (
+                "Upload the signed {xpi_name} " "XPI package to {xpi_destination}"
+            ).format(xpi_name=xpi_name, xpi_destination=xpi_destination)
+            for task in tasks:
+                resolve_keyed_by(
+                    task,
+                    "bucket-scope",
+                    item_name=task_label,
+                    **{"level": config.params["level"]},
+                )
+                dep = task["primary-dependency"]
+                task_ref = {"task-reference": "<release-signing>"}
+                branch = basename(config.params["head_ref"])
+                paths = list(dep.attributes["xpis"].values())
+                artifact_map_paths = {
+                    path: {"destinations": xpi_destinations} for path in paths
+                }
+                worker = {
+                    "upstream-artifacts": [
+                        {
+                            "taskId": task_ref,
+                            "taskType": "signing",
+                            "paths": paths,
+                            "locale": "multi",
+                        },
+                    ],
+                    "action-scope": "direct-push-to-bucket",
+                    "bucket-scope": task["bucket-scope"],
+                    "release-properties": {
+                        "app-name": "xpi",
+                        "app-version": xpi_version,
+                        "branch": branch,
+                        "build-id": config.params["moz_build_date"],
+                    },
+                    "artifact-map": [
+                        {
+                            "taskId": task_ref,
+                            "paths": artifact_map_paths,
+                        },
+                    ],
+                }
+                task = {
+                    "label": task_label,
+                    "name": task_label,
+                    "description": task_description,
+                    "dependencies": {"release-signing": dep.label},
+                    "worker-type": task["worker-type"],
+                    "worker": worker,
+                    "attributes": task["attributes"],
+                    "run-on-tasks-for": task["run-on-tasks-for"],
+                }
+                yield task

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from os.path import basename
+from os.path import basename, splitext
 
 from taskgraph.task import Task
 from taskgraph.transforms.base import TransformSequence
@@ -45,12 +45,13 @@ def add_beetmover_worker_config(config, tasks):
             xpi_version = config.params["version"]
             xpi_destinations = []
             for artifact in xpi_manifest["artifacts"]:
-                artifact_name = basename(artifact)
+                artifact_name = splitext(basename(artifact))[0]
                 xpi_destination = (
                     "pub/system-addons/{xpi_name}/"
-                    "{xpi_name}%mozilla.org-{xpi_version}-{build_id}.xpi"
+                    "{artifact_name}_mozilla.org-{xpi_version}-{build_id}.xpi"
                 ).format(
-                    xpi_name=artifact_name,
+                    xpi_name=xpi_name,
+                    artifact_name=artifact_name,
                     xpi_version=xpi_version,
                     build_id=config.params["moz_build_date"],
                 )

--- a/taskcluster/xpi_taskgraph/worker_types.py
+++ b/taskcluster/xpi_taskgraph/worker_types.py
@@ -2,10 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from voluptuous import Required
 
-from taskgraph.util.schema import taskref_or_string
+from datetime import datetime
+
 from taskgraph.transforms.task import payload_builder
+from taskgraph.util.schema import taskref_or_string
+from voluptuous import Any, Optional, Required
 
 
 @payload_builder(
@@ -100,3 +102,78 @@ def build_github_release_payload(config, task, task_def):
             "{}:github:action:{}".format(scope_prefix, worker["action"]),
         ]
     )
+
+
+@payload_builder(
+    "scriptworker-beetmover",
+    schema={
+        Required("action-scope"): str,
+        Required("bucket-scope"): str,
+        Required("artifact-map"): [
+            {
+                Required("paths"): {
+                    Any(str): {
+                        Required("destinations"): [str],
+                    },
+                },
+                Required("taskId"): taskref_or_string,
+            }
+        ],
+        Required("release-properties"): {
+            Required("app-name"): str,
+            Required("app-version"): str,
+            Required("branch"): str,
+            Required("build-id"): str,
+            Optional("hash-type"): str,
+            Optional("platform"): str,
+        },
+        Required("upstream-artifacts"): [
+            {
+                Required("locale"): str,
+                Required("taskId"): taskref_or_string,
+                Required("taskType"): str,
+                Required("paths"): [str],
+            }
+        ],
+    },
+)
+def build_scriptworker_beetmover_payload(config, task, task_def):
+    worker = task["worker"]
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+    artifact_map = worker["artifact-map"]
+    for map_ in artifact_map:
+        map_["locale"] = "multi"
+        for path_config in map_["paths"].values():
+            path_config["checksums_path"] = ""
+    if worker["release-properties"].get("hash-type"):
+        hash_type = worker["release-properties"]["hash-type"]
+    else:
+        hash_type = "sha512"
+    if worker["release-properties"].get("platform"):
+        platform = worker["release-properties"]["platform"]
+    else:
+        platform = "xpi"
+    release_properties = {
+        "appName": worker["release-properties"]["app-name"],
+        "appVersion": worker["release-properties"]["app-version"],
+        "branch": worker["release-properties"]["branch"],
+        "buildid": worker["release-properties"]["build-id"],
+        "hashType": hash_type,
+        "platform": platform,
+    }
+    prefix = "project:xpi:beetmover:"
+    task_def["scopes"] = [
+        "{prefix}bucket:{bucket_scope}".format(
+            prefix=prefix, bucket_scope=worker["bucket-scope"]
+        ),
+        "{prefix}action:{action_scope}".format(
+            prefix=prefix, action_scope=worker["action-scope"]
+        ),
+    ]
+    task_def["payload"] = {
+        "maxRunTime": 600,
+        "artifactMap": artifact_map,
+        "releaseProperties": release_properties,
+        "upstreamArtifacts": worker["upstream-artifacts"],
+        "upload_date": int(datetime.now().timestamp()),
+    }

--- a/taskcluster/xpi_taskgraph/worker_types.py
+++ b/taskcluster/xpi_taskgraph/worker_types.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 from datetime import datetime
+from os.path import basename
 
 from taskgraph.transforms.task import payload_builder
 from taskgraph.util.schema import taskref_or_string
@@ -144,7 +144,9 @@ def build_scriptworker_beetmover_payload(config, task, task_def):
     for map_ in artifact_map:
         map_["locale"] = "multi"
         for path_config in map_["paths"].values():
-            path_config["checksums_path"] = ""
+            for destination in path_config["destinations"]:
+                path_config["checksums_path"] = basename(destination)
+                path_config["update_balrog_manifest"] = True
     if worker["release-properties"].get("hash-type"):
         hash_type = worker["release-properties"]["hash-type"]
     else:


### PR DESCRIPTION
This PR adds a beetmover task to the xpi taskgraph that uploads signed system addon blobs to the Mozilla file archive @ https://archive.mozilla.org

I've tested this in the staging. Links below.

* [task graph](https://firefox-ci-tc.services.mozilla.com/tasks/bhUTRRxPTJiJ5h-ko6Divg#artifacts)
* [task group](https://firefox-ci-tc.services.mozilla.com/tasks/groups/bhUTRRxPTJiJ5h-ko6Divg)
* [archived blob](https://ftp.stage.mozaws.net/pub/system-addons/balrog-dryrun/)