### PR TITLE
Add manifest for dnssec-interference Normandy study

### DIFF
--- a/manifests/dnssec-interference.yml
+++ b/manifests/dnssec-interference.yml
@@ -1,0 +1,9 @@
+---    
+description: DNSSEC Interference Study
+repo-prefix: dnssecinterferencestudy
+active: true
+private-repo: false
+artifacts:
+    - web-ext-artifacts/dnssec-interference-study.xpi
+addon-type: privileged
+install-type: npm


### PR DESCRIPTION
We plan on launching the third iteration of a Normandy study titled dnssec-interference. We have set up xpi-manifest for our add-on [in the past,](https://github.com/mozilla-extensions/xpi-manifest/commit/b8bbfbb89c4424119d1ab7d86b1daedd75967c81) but since then it looks like the xpi-manifest.yml file was deleted. This commit adds our add-on back to xpi-manifest, and sets it up for release builds.