### PR TITLE
reenable normandy-privileged

### DIFF
--- a/docs/releasing-a-xpi.md
+++ b/docs/releasing-a-xpi.md
@@ -86,3 +86,4 @@ Privileged webextension admin | Add-on Review team (+releng as backups) | privil
 System addon admin | Add-on Review team (+releng as backups) | system | Two of these are required to sign off on `system` xpis.
 MozillaOnline privileged webextension team | mozilla-online team (+releng as backups) | mozillaonline-privileged | One of each (team and admin) need to sign off on `mozillaonline-privileged` xpis.
 MozillaOnline privileged webextension admin | `:theone` and `:mkaply` (+releng as backups) | mozillaonline-privileged | One of each (team and admin) need to sign off on `mozillaonline-privileged` xpis.
+Normandy privileged signoff | (currently only releng) | normandy-privileged | Two are required to sign off on `normandy-privileged` xpis. `normandy-privileged` is deprecated.

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -173,6 +173,8 @@ scriptworker:
             mozillaonline-privileged: privileged_webextension
             privileged: privileged_webextension
             system: system_addon
+            # normandy-privileged is deprecated
+            normandy-privileged: privileged_webextension
 
 release-promotion:
     flavors:
@@ -239,3 +241,7 @@ release-promotion:
                             - "awagner+system-addons-ship@mozilla.com"
                             - "pkewisch+system-addons-ship@mozilla.com"
                 default: []
+        # configure normandy-privileged webextension email addresses for
+        # notifications. normandy-privileged is deprecated.
+        normandy-privileged:
+            - "aki+normandy-priv@mozilla.com"

--- a/taskcluster/xpi_taskgraph/xpi_manifest.py
+++ b/taskcluster/xpi_taskgraph/xpi_manifest.py
@@ -34,7 +34,10 @@ base_schema = Schema(
         Optional("branch"): str,
         Optional("docker-image"): str,
         Required("artifacts"): [str],
-        Required("addon-type"): Any("mozillaonline-privileged", "privileged", "system"),
+        # normandy-privileged is deprecated
+        Required("addon-type"): Any(
+            "mozillaonline-privileged", "normandy-privileged", "privileged", "system"
+        ),
         Optional("install-type"): Any("npm", "yarn"),
         Optional("enable-github-release"): bool,
         Optional("release-tag"): str,


### PR DESCRIPTION
Reverts the format portions of #132.

We have an unexpected `normandy-privileged` release coming, and
there's [pushback](https://github.com/mozilla-extensions/xpi-manifest/pull/149#discussion_r801858020) against using the `privileged` format for this,
even if they both use the exact same signing format behind the scenes.

Let's reenable `normandy-privileged` and leave it enabled until it's
clear we will definitely not ship any more normandy-privileged addons.