### PR TITLE
Add balrog release task

### DIFF
--- a/taskcluster/ci/balrog/kind.yml
+++ b/taskcluster/ci/balrog/kind.yml
@@ -17,6 +17,5 @@ job-template:
             by-level:
                 '3': "release"
                 default: "staging"
-        channel: release
     attributes:
         shipping-phase: ship

--- a/taskcluster/ci/balrog/kind.yml
+++ b/taskcluster/ci/balrog/kind.yml
@@ -8,14 +8,15 @@ transforms:
 kind-dependencies:
     - beetmover
 
+only-for-addon-types: ["system"]
+
 job-template:
     run-on-tasks-for: ["action"]
-    only-for-addon-types: ["system"]
     worker-type: balrog
     balrog:
         server:
             by-level:
-                '3': "release"
+                "3": "release"
                 default: "staging"
     attributes:
         shipping-phase: ship

--- a/taskcluster/ci/balrog/kind.yml
+++ b/taskcluster/ci/balrog/kind.yml
@@ -1,0 +1,22 @@
+---
+loader: xpi_taskgraph.loader.single_dep:loader
+
+transforms:
+    - xpi_taskgraph.transforms.balrog:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - beetmover
+
+job-template:
+    run-on-tasks-for: ["action"]
+    only-for-addon-types: ["system"]
+    worker-type: balrog
+    balrog:
+        server:
+            by-level:
+                '3': "release"
+                default: "staging"
+        channel: release
+    attributes:
+        shipping-phase: ship

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -11,13 +11,14 @@ transforms:
 kind-dependencies:
     - release-signing
 
+only-for-addon-types: ["system"]
+
 job-template:
     run-on-tasks-for: ["action"]
-    only-for-addon-types: ["system"]
     worker-type: beetmover
     attributes:
         shipping-phase: ship
     bucket-scope:
         by-level:
-            '3': "release"
+            "3": "release"
             default: "dep"

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -147,11 +147,6 @@ workers:
             implementation: scriptworker-beetmover
             os: scriptworker
             worker-type: 'xpi-{level}-beetmover'
-        balrog:
-            provisioner: scriptworker-k8s
-            implementation: scriptworker-balrog
-            os: scriptworker
-            worker-type: 'xpi-{level}-balrog'
         signing:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -147,6 +147,11 @@ workers:
             implementation: scriptworker-beetmover
             os: scriptworker
             worker-type: 'xpi-{level}-beetmover'
+        balrog:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-balrog
+            os: scriptworker
+            worker-type: 'xpi-{level}-balrog'
         signing:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing

--- a/taskcluster/ci/release-mark-as-shipped/kind.yml
+++ b/taskcluster/ci/release-mark-as-shipped/kind.yml
@@ -2,14 +2,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-loader: xpi_taskgraph.loader.single_dep:loader
+loader: xpi_taskgraph.loader.multi_dep:loader
 
 transforms:
     - xpi_taskgraph.transforms.release_mark_as_shipped:transforms
     - taskgraph.transforms.task:transforms
 
+primary-dependency: release-signing
+
 kind-dependencies:
     - release-signing
+    - beetmover
+    - balrog
+
+group-by: addon-type
 
 job-template:
     name: release-mark-as-shipped

--- a/taskcluster/xpi_taskgraph/loader/multi_dep.py
+++ b/taskcluster/xpi_taskgraph/loader/multi_dep.py
@@ -1,0 +1,96 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import copy
+
+from taskgraph.task import Task
+from taskgraph.util.attributes import sorted_unique_list
+from taskgraph.util.schema import Schema
+from voluptuous import Required
+
+schema = Schema(
+    {
+        Required("primary-dependency"): Task,
+        Required("dependent-tasks"): {str: Task},
+    },
+)
+
+GROUP_BY_MAP = {}
+
+
+def group_by(name):
+    def wrapper(func):
+        GROUP_BY_MAP[name] = func
+        return func
+
+    return wrapper
+
+
+@group_by("addon-type")
+def group_by_addon_type(config, tasks):
+    groups = {}
+    kind_dependencies = config.get("kind-dependencies")
+    only_addon_types = config.get("only-for-addon-types")
+    for task in tasks:
+        if task.kind not in kind_dependencies:
+            continue
+        if only_addon_types:
+            addon_type = task.attributes.get("addon-type")
+            if not addon_type in only_addon_types:
+                continue
+        addon_type = task.attributes.get("addon-type")
+        groups.setdefault(addon_type, []).append(task)
+    return groups
+
+
+def group_tasks(config, tasks):
+    group_by_fn = GROUP_BY_MAP[config["group-by"]]
+    groups = group_by_fn(config, tasks)
+    for combinations in groups.values():
+        dependencies = [copy.deepcopy(t) for t in combinations]
+        yield dependencies
+
+
+def loader(kind, path, config, params, loaded_tasks):
+    job_template = config.get("job-template")
+    for dep_tasks in group_tasks(config, loaded_tasks):
+        kinds = [dep.kind for dep in dep_tasks]
+        kinds_occurrences = {kind: kinds.count(kind) for kind in kinds}
+        dep_tasks_per_unique_key = {
+            dep.kind if kinds_occurrences[dep.kind] == 1 else dep.label: dep
+            for dep in dep_tasks
+        }
+        job = {"dependent-tasks": dep_tasks_per_unique_key}
+        job["primary-dependency"] = get_primary_dep(config, dep_tasks_per_unique_key)
+        if job_template:
+            job.update(copy.deepcopy(job_template))
+        yield job
+
+
+def get_primary_dep(config, dep_tasks):
+    primary_dependencies = config.get("primary-dependency")
+    if isinstance(primary_dependencies, str):
+        primary_dependencies = [primary_dependencies]
+    if not primary_dependencies:
+        assert len(dep_tasks) == 1, "Must define a primary-dependency!"
+        return dep_tasks.values()[0]
+    primary_dep = None
+    for primary_kind in primary_dependencies:
+        for dep_kind in dep_tasks:
+            if dep_kind == primary_kind:
+                assert (
+                    primary_dep is None
+                ), "Too many primary dependent tasks in dep_tasks: {}!".format(
+                    [t.label for t in dep_tasks],
+                )
+                primary_dep = dep_tasks[dep_kind]
+    if primary_dep is None:
+        raise Exception(
+            "Can't find dependency of {}: {}".format(
+                config["primary-dependency"],
+                config,
+            ),
+        )
+    return primary_dep

--- a/taskcluster/xpi_taskgraph/loader/single_dep.py
+++ b/taskcluster/xpi_taskgraph/loader/single_dep.py
@@ -25,6 +25,7 @@ def loader(kind, path, config, params, loaded_tasks):
     pass configuration down to the specified transforms used.
     """
     only_attributes = config.get("only-for-attributes")
+    only_addon_types = config.get("only-for-addon-types")
     job_template = config.get("job-template")
 
     for task in loaded_tasks:
@@ -35,6 +36,11 @@ def loader(kind, path, config, params, loaded_tasks):
             config_attrs = set(only_attributes)
             if not config_attrs & set(task.attributes):
                 # make sure any attribute exists
+                continue
+
+        if only_addon_types:
+            addon_type = task.attributes.get("addon-type")
+            if not addon_type in only_addon_types:
                 continue
 
         job = {"primary-dependency": task}

--- a/taskcluster/xpi_taskgraph/transforms/balrog.py
+++ b/taskcluster/xpi_taskgraph/transforms/balrog.py
@@ -66,7 +66,6 @@ def add_balrog_worker_config(config, tasks):
             worker = {
                 "action": "submit-system-addons",
                 "server": task["balrog"]["server"],
-                "channel": task["balrog"]["channel"],
                 "upstream-artifacts": [
                     {
                         "taskId": task_ref,

--- a/taskcluster/xpi_taskgraph/transforms/balrog.py
+++ b/taskcluster/xpi_taskgraph/transforms/balrog.py
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from os.path import basename
+
+from taskgraph.task import Task
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+from voluptuous import Required, Schema
+from xpi_taskgraph.xpi_manifest import get_manifest
+
+transforms = TransformSequence()
+schema = Schema(
+    {
+        Required("primary-dependency"): Task,
+        Required("worker-type"): str,
+        Required("attributes"): dict,
+        Required("run-on-tasks-for"): [str],
+        Required("balrog"): dict,
+        Required("only-for-addon-types"): [str],
+    },
+)
+transforms = TransformSequence()
+transforms.add_validate(schema)
+
+
+@transforms.add
+def add_balrog_worker_config(config, tasks):
+    if (
+        config.params.get("version")
+        and config.params.get("xpi_name")
+        and config.params.get("head_ref")
+        and config.params.get("build_number")
+        and config.params.get("level")
+    ):
+        manifest = get_manifest()
+        xpi_name = config.params["xpi_name"]
+        xpi_manifest = manifest[xpi_name]
+        xpi_addon_type = xpi_manifest["addon-type"]
+        xpi_version = config.params["version"]
+        build_number = config.params["build_number"]
+        release_name = (
+            "{xpi_name}-{xpi_version}-build{build_number}"
+        ).format(
+            xpi_name=xpi_name,
+            xpi_version=xpi_version,
+            build_number=build_number,
+        )
+        task_label = f"balrog-{xpi_name}"
+        task_description = (
+            "Create a Balrog release for the signed "
+            "XPI artifacts uploaded to "
+            "pub/system-addons/{xpi_name}/{release_name}/"
+        ).format(xpi_name=xpi_name, release_name=release_name)
+        for task in tasks:
+            if xpi_addon_type not in task["only-for-addon-types"]:
+                continue
+            dep = task["primary-dependency"]
+            task_ref = {"task-reference": "<beetmover>"}
+            paths = [
+                "public/manifest.json",
+                "public/target.checksums",
+            ]
+            worker = {
+                "action": "submit-system-addons",
+                "server": task["balrog"]["server"],
+                "channel": task["balrog"]["channel"],
+                "upstream-artifacts": [
+                    {
+                        "taskId": task_ref,
+                        "taskType": "beetmover",
+                        "paths": paths,
+                    },
+                ],
+            }
+            resolve_keyed_by(
+                worker,
+                "server",
+                item_name=task_label,
+                **{"level": config.params["level"]},
+            )
+            task = {
+                "label": task_label,
+                "name": task_label,
+                "description": task_description,
+                "dependencies": {"beetmover": dep.label},
+                "worker-type": task["worker-type"],
+                "worker": worker,
+                "attributes": task["attributes"],
+                "run-on-tasks-for": task["run-on-tasks-for"],
+            }
+            yield task

--- a/taskcluster/xpi_taskgraph/transforms/balrog.py
+++ b/taskcluster/xpi_taskgraph/transforms/balrog.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from os.path import basename
-
 from taskgraph.task import Task
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by
@@ -19,7 +17,6 @@ schema = Schema(
         Required("attributes"): dict,
         Required("run-on-tasks-for"): [str],
         Required("balrog"): dict,
-        Required("only-for-addon-types"): [str],
     },
 )
 transforms = TransformSequence()
@@ -41,9 +38,7 @@ def add_balrog_worker_config(config, tasks):
         xpi_addon_type = xpi_manifest["addon-type"]
         xpi_version = config.params["version"]
         build_number = config.params["build_number"]
-        release_name = (
-            "{xpi_name}-{xpi_version}-build{build_number}"
-        ).format(
+        release_name = "{xpi_name}-{xpi_version}-build{build_number}".format(
             xpi_name=xpi_name,
             xpi_version=xpi_version,
             build_number=build_number,
@@ -55,8 +50,6 @@ def add_balrog_worker_config(config, tasks):
             "pub/system-addons/{xpi_name}/{release_name}/"
         ).format(xpi_name=xpi_name, release_name=release_name)
         for task in tasks:
-            if xpi_addon_type not in task["only-for-addon-types"]:
-                continue
             dep = task["primary-dependency"]
             task_ref = {"task-reference": "<beetmover>"}
             paths = [
@@ -80,6 +73,7 @@ def add_balrog_worker_config(config, tasks):
                 item_name=task_label,
                 **{"level": config.params["level"]},
             )
+            task.setdefault("attributes", {})["addon-type"] = xpi_addon_type
             task = {
                 "label": task_label,
                 "name": task_label,

--- a/taskcluster/xpi_taskgraph/transforms/balrog.py
+++ b/taskcluster/xpi_taskgraph/transforms/balrog.py
@@ -19,7 +19,6 @@ schema = Schema(
         Required("balrog"): dict,
     },
 )
-transforms = TransformSequence()
 transforms.add_validate(schema)
 
 

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -21,7 +21,6 @@ schema = Schema(
         Required("run-on-tasks-for"): [str],
     },
 )
-transforms = TransformSequence()
 transforms.add_validate(schema)
 
 

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -19,7 +19,6 @@ schema = Schema(
         Required("attributes"): dict,
         Required("bucket-scope"): dict,
         Required("run-on-tasks-for"): [str],
-        Required("only-for-addon-types"): [str],
     },
 )
 transforms = TransformSequence()
@@ -41,16 +40,12 @@ def add_beetmover_worker_config(config, tasks):
         xpi_addon_type = xpi_manifest["addon-type"]
         build_number = config.params["build_number"]
         xpi_version = config.params["version"]
-        release_name = (
-            "{xpi_name}-{xpi_version}-build{build_number}"
-        ).format(
+        release_name = ("{xpi_name}-{xpi_version}-build{build_number}").format(
             xpi_name=xpi_name,
             xpi_version=xpi_version,
             build_number=build_number,
         )
         for task in tasks:
-            if xpi_addon_type not in task["only-for-addon-types"]:
-                continue
             xpi_destinations = []
             for artifact in xpi_manifest["artifacts"]:
                 artifact_name = basename(artifact)
@@ -104,6 +99,7 @@ def add_beetmover_worker_config(config, tasks):
                     },
                 ],
             }
+            task.setdefault("attributes", {})["addon-type"] = xpi_addon_type
             task = {
                 "label": task_label,
                 "name": task_label,

--- a/taskcluster/xpi_taskgraph/transforms/beetmover.py
+++ b/taskcluster/xpi_taskgraph/transforms/beetmover.py
@@ -27,14 +27,16 @@ transforms.add_validate(schema)
 
 @transforms.add
 def add_beetmover_worker_config(config, tasks):
-    if (
-        config.params.get("version")
-        and config.params.get("xpi_name")
-        and config.params.get("head_ref")
-        and config.params.get("build_number")
-        and config.params.get("level")
-    ):
-        manifest = get_manifest()
+    manifest = get_manifest()
+    for task in tasks:
+        if not (
+            config.params.get("version")
+            and config.params.get("xpi_name")
+            and config.params.get("head_ref")
+            and config.params.get("build_number")
+            and config.params.get("level")
+        ):
+            continue
         xpi_name = config.params["xpi_name"]
         xpi_manifest = manifest[xpi_name]
         xpi_addon_type = xpi_manifest["addon-type"]
@@ -45,69 +47,68 @@ def add_beetmover_worker_config(config, tasks):
             xpi_version=xpi_version,
             build_number=build_number,
         )
-        for task in tasks:
-            xpi_destinations = []
-            for artifact in xpi_manifest["artifacts"]:
-                artifact_name = basename(artifact)
-                xpi_destination = (
-                    "pub/system-addons/{xpi_name}/{release_name}/{artifact_name}"
-                ).format(
-                    xpi_name=xpi_name,
-                    artifact_name=artifact_name,
-                    release_name=release_name,
-                )
-                xpi_destinations.append(xpi_destination)
-            task_label = f"beetmover-{xpi_name}"
-            task_description = (
-                "Upload signed XPI artifacts to "
-                "pub/system-addons/{xpi_name}/{release_name}"
-            ).format(xpi_name=xpi_name, release_name=release_name)
-            resolve_keyed_by(
-                task,
-                "bucket-scope",
-                item_name=task_label,
-                **{"level": config.params["level"]},
+        xpi_destinations = []
+        for artifact in xpi_manifest["artifacts"]:
+            artifact_name = basename(artifact)
+            xpi_destination = (
+                "pub/system-addons/{xpi_name}/{release_name}/{artifact_name}"
+            ).format(
+                xpi_name=xpi_name,
+                artifact_name=artifact_name,
+                release_name=release_name,
             )
-            dep = task["primary-dependency"]
-            task_ref = {"task-reference": "<release-signing>"}
-            branch = basename(config.params["head_ref"])
-            paths = list(dep.attributes["xpis"].values())
-            artifact_map_paths = {
-                path: {"destinations": xpi_destinations} for path in paths
-            }
-            worker = {
-                "upstream-artifacts": [
-                    {
-                        "taskId": task_ref,
-                        "taskType": "signing",
-                        "paths": paths,
-                        "locale": "multi",
-                    },
-                ],
-                "action-scope": "push-to-system-addons",
-                "bucket-scope": task["bucket-scope"],
-                "release-properties": {
-                    "app-name": "xpi",
-                    "app-version": xpi_version,
-                    "branch": branch,
-                    "build-id": release_name,
+            xpi_destinations.append(xpi_destination)
+        task_label = f"beetmover-{xpi_name}"
+        task_description = (
+            "Upload signed XPI artifacts to "
+            "pub/system-addons/{xpi_name}/{release_name}"
+        ).format(xpi_name=xpi_name, release_name=release_name)
+        resolve_keyed_by(
+            task,
+            "bucket-scope",
+            item_name=task_label,
+            **{"level": config.params["level"]},
+        )
+        dep = task["primary-dependency"]
+        task_ref = {"task-reference": "<release-signing>"}
+        branch = basename(config.params["head_ref"])
+        paths = list(dep.attributes["xpis"].values())
+        artifact_map_paths = {
+            path: {"destinations": xpi_destinations} for path in paths
+        }
+        worker = {
+            "upstream-artifacts": [
+                {
+                    "taskId": task_ref,
+                    "taskType": "signing",
+                    "paths": paths,
+                    "locale": "multi",
                 },
-                "artifact-map": [
-                    {
-                        "taskId": task_ref,
-                        "paths": artifact_map_paths,
-                    },
-                ],
-            }
-            task.setdefault("attributes", {})["addon-type"] = xpi_addon_type
-            task = {
-                "label": task_label,
-                "name": task_label,
-                "description": task_description,
-                "dependencies": {"release-signing": dep.label},
-                "worker-type": task["worker-type"],
-                "worker": worker,
-                "attributes": task["attributes"],
-                "run-on-tasks-for": task["run-on-tasks-for"],
-            }
-            yield task
+            ],
+            "action-scope": "push-to-system-addons",
+            "bucket-scope": task["bucket-scope"],
+            "release-properties": {
+                "app-name": "xpi",
+                "app-version": xpi_version,
+                "branch": branch,
+                "build-id": release_name,
+            },
+            "artifact-map": [
+                {
+                    "taskId": task_ref,
+                    "paths": artifact_map_paths,
+                },
+            ],
+        }
+        task.setdefault("attributes", {})["addon-type"] = xpi_addon_type
+        task = {
+            "label": task_label,
+            "name": task_label,
+            "description": task_description,
+            "dependencies": {"release-signing": dep.label},
+            "worker-type": task["worker-type"],
+            "worker": worker,
+            "attributes": task["attributes"],
+            "run-on-tasks-for": task["run-on-tasks-for"],
+        }
+        yield task

--- a/taskcluster/xpi_taskgraph/transforms/signing.py
+++ b/taskcluster/xpi_taskgraph/transforms/signing.py
@@ -19,61 +19,75 @@ KNOWN_FORMATS = ("privileged_webextension", "system_addon")
 
 @transforms.add
 def define_signing_flags(config, tasks):
-    for task in tasks:
-        dep = task["primary-dependency"]
-        # Current kind will be prepended later in the transform chain.
-        task["name"] = _get_dependent_job_name_without_its_kind(dep)
-        attributes = dep.attributes.copy()
-        if task.get("attributes"):
-            attributes.update(task["attributes"])
-        task["attributes"] = attributes
-        task["attributes"]["signed"] = True
-        if "run_on_tasks_for" in task["attributes"]:
-            task.setdefault("run-on-tasks-for", task["attributes"]["run_on_tasks_for"])
+    if (
+        config.params.get("version")
+        and config.params.get("xpi_name")
+        and config.params.get("head_ref")
+        and config.params.get("build_number")
+        and config.params.get("level")
+    ):
+        for task in tasks:
+            dep = task["primary-dependency"]
+            # Current kind will be prepended later in the transform chain.
+            task["name"] = _get_dependent_job_name_without_its_kind(dep)
+            attributes = dep.attributes.copy()
+            if task.get("attributes"):
+                attributes.update(task["attributes"])
+            task["attributes"] = attributes
+            task["attributes"]["signed"] = True
+            if "run_on_tasks_for" in task["attributes"]:
+                task.setdefault("run-on-tasks-for", task["attributes"]["run_on_tasks_for"])
 
-        for key in ("worker-type", "worker.signing-type"):
-            resolve_keyed_by(
-                task, key, item_name=task["name"], level=config.params["level"]
-            )
-        yield task
+            for key in ("worker-type", "worker.signing-type"):
+                resolve_keyed_by(
+                    task, key, item_name=task["name"], level=config.params["level"]
+                )
+            yield task
 
 
 @transforms.add
 def build_signing_task(config, tasks):
-    for task in tasks:
-        dep = task["primary-dependency"]
-        task["dependencies"] = {"build": dep.label}
-        if not dep.task["payload"]["env"]["ARTIFACT_PREFIX"].startswith("public"):
-            scopes = task.setdefault("scopes", [])
-            scopes.append(
-                "queue:get-artifact:{}/*".format(
-                    dep.task["payload"]["env"]["ARTIFACT_PREFIX"].rstrip("/")
+    if (
+        config.params.get("version")
+        and config.params.get("xpi_name")
+        and config.params.get("head_ref")
+        and config.params.get("build_number")
+        and config.params.get("level")
+    ):
+        for task in tasks:
+            dep = task["primary-dependency"]
+            task["dependencies"] = {"build": dep.label}
+            if not dep.task["payload"]["env"]["ARTIFACT_PREFIX"].startswith("public"):
+                scopes = task.setdefault("scopes", [])
+                scopes.append(
+                    "queue:get-artifact:{}/*".format(
+                        dep.task["payload"]["env"]["ARTIFACT_PREFIX"].rstrip("/")
+                    )
                 )
-            )
 
-        paths = list(dep.attributes["xpis"].values())
-        format = evaluate_keyed_by(
-            config.graph_config["scriptworker"]["signing-format"],
-            "signing-format",
-            {
-                "xpi-type": task["attributes"]["addon-type"],
-                "kind": config.kind,
-                "level": config.params["level"],
-            },
-        )
-        assert format in KNOWN_FORMATS
-        task["worker"]["upstream-artifacts"] = [
-            {
-                "taskId": {"task-reference": "<build>"},
-                "taskType": "build",
-                "paths": paths,
-                "formats": [format],
-            }
-        ]
-        task.setdefault("extra", {})["xpi-name"] = dep.task["extra"]["xpi-name"]
-        task["extra"]["artifact_prefix"] = dep.task["payload"]["env"]["ARTIFACT_PREFIX"]
-        del task["primary-dependency"]
-        yield task
+            paths = list(dep.attributes["xpis"].values())
+            format = evaluate_keyed_by(
+                config.graph_config["scriptworker"]["signing-format"],
+                "signing-format",
+                {
+                    "xpi-type": task["attributes"]["addon-type"],
+                    "kind": config.kind,
+                    "level": config.params["level"],
+                },
+            )
+            assert format in KNOWN_FORMATS
+            task["worker"]["upstream-artifacts"] = [
+                {
+                    "taskId": {"task-reference": "<build>"},
+                    "taskType": "build",
+                    "paths": paths,
+                    "formats": [format],
+                }
+            ]
+            task.setdefault("extra", {})["xpi-name"] = dep.task["extra"]["xpi-name"]
+            task["extra"]["artifact_prefix"] = dep.task["payload"]["env"]["ARTIFACT_PREFIX"]
+            del task["primary-dependency"]
+            yield task
 
 
 def _get_dependent_job_name_without_its_kind(dependent_job):

--- a/taskcluster/xpi_taskgraph/worker_types.py
+++ b/taskcluster/xpi_taskgraph/worker_types.py
@@ -184,7 +184,6 @@ def build_scriptworker_beetmover_payload(config, task, task_def):
     "scriptworker-balrog",
     schema={
         Required("action"): str,
-        Required("channel"): str,
         Required("server"): str,
         Required("upstream-artifacts"): [
             {

--- a/taskcluster/xpi_taskgraph/worker_types.py
+++ b/taskcluster/xpi_taskgraph/worker_types.py
@@ -146,7 +146,6 @@ def build_scriptworker_beetmover_payload(config, task, task_def):
         for path_config in map_["paths"].values():
             for destination in path_config["destinations"]:
                 path_config["checksums_path"] = basename(destination)
-                path_config["update_balrog_manifest"] = True
     if worker["release-properties"].get("hash-type"):
         hash_type = worker["release-properties"]["hash-type"]
     else:
@@ -179,3 +178,36 @@ def build_scriptworker_beetmover_payload(config, task, task_def):
         "upstreamArtifacts": worker["upstream-artifacts"],
         "upload_date": int(datetime.now().timestamp()),
     }
+
+
+@payload_builder(
+    "scriptworker-balrog",
+    schema={
+        Required("action"): str,
+        Required("channel"): str,
+        Required("server"): str,
+        Required("upstream-artifacts"): [
+            {
+                Required("taskId"): taskref_or_string,
+                Required("taskType"): str,
+                Required("paths"): [str],
+            }
+        ], 
+    }
+)
+def build_scriptworker_balrog_payload(config, task, task_def):
+    worker = task["worker"]
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+    task_def["payload"] = {
+        "maxRunTime": 600,
+        "upstreamArtifacts": worker["upstream-artifacts"],
+    }
+    prefix = "project:xpi:balrog:"
+    task_def["scopes"] = [
+        "{prefix}action:{action}".format(
+            prefix=prefix, action=worker["action"]
+        ),
+        "{prefix}server:{server}".format(
+            prefix=prefix, server=worker["server"]
+        ),
+    ]


### PR DESCRIPTION
These changes modify the `xpi_taskgraph` to run `beetmover` & `balrog` tasks for system add-on releases during the release shipping phase.

I tested these changes in staging by shipping the webcompat system add-on.

**Links**

- [system add-on shipping tasks](https://firefox-ci-tc.services.mozilla.com/tasks/groups/NIf4H6TqR0WVX124kKbnsA)
- [archived system add-on xpi](https://ftp.stage.mozaws.net/pub/system-addons/webcompat/webcompat-30.2.0-build1/)
- [system add-on balrog release](https://balrog-admin-static-stage.stage.mozaws.net/releases#webcompat-30.2.0-build1)

> Note: I need to deploy changes to balrog & scriptworker-scripts before merging these changes