### PR TITLE
Enable releases of aboutsync

### DIFF
--- a/manifests/aboutsync.yml
+++ b/manifests/aboutsync.yml
@@ -1,0 +1,9 @@
+description: About Sync
+repo-prefix: aboutsync
+active: true
+private-repo: false
+additional-emails: ["mhammond@mozilla.com", "skhamis@mozilla.com"]
+artifacts:
+  - web-ext-artifacts/aboutsync.xpi
+addon-type: privileged
+install-type: npm

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -123,6 +123,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/firefox-translations
             default-ref: main
             type: git
+        aboutsync:
+            name: "About Sync"
+            project-regex: aboutsync$
+            default-repository: https://github.com/mozilla-extensions/aboutsync
+            default-ref: main
+            type: git
 
     cached-task-prefix: xpi
 


### PR DESCRIPTION
Attempting to follow the instructions at https://github.com/mozilla-extensions/xpi-manifest/blob/master/docs/adding-a-new-xpi.md#enabling-releases