### PR TITLE
Enable github releases for aboutsync

### DIFF
--- a/manifests/aboutsync.yml
+++ b/manifests/aboutsync.yml
@@ -9,3 +9,4 @@ artifacts:
   - web-ext-artifacts/aboutsync.xpi
 addon-type: privileged
 install-type: npm
+enable-github-release: true


### PR DESCRIPTION
In slack, @wagnerand suggested we enable github releases for aboutsync. I *think* this is needed, but not sure if that's all that's needed?