### PR TITLE
Add a new `addons-linter` kind to run mozilla/addons-linter after the build tasks

### DIFF
--- a/taskcluster/ci/addons-linter/kind.yml
+++ b/taskcluster/ci/addons-linter/kind.yml
@@ -13,16 +13,22 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 job-template:
-    description: Test XPI
+    description: Run addons-linter
     worker-type: b-linux
+    # We only want to execute addons-linter on privileged extensions (for now).
+    only-for-formats: ["privileged"]
     worker:
-        docker-image: {in-tree: node-16}
+        docker-image:
+            in-tree: node-16
         max-run-time: 7200
     run:
         using: run-task
+        cache-dotcache: false
         use-caches: false
         cwd: '{checkout}'
-        cache-dotcache: false
+        # TODO: We should enable MV3 when we are ready to accept MV3 add-ons.
+        # This should be done by replacing `2` with `3` in the command below.
         command: >-
-            python3 /usr/local/bin/test.py
+            curl -sSL --fail --retry 3 -o {xpi_file} "$XPI_URL" &&
+            npx -y addons-linter@5.4.0 --privileged --boring --disable-xpi-autoclose --max-manifest-version=2 {xpi_file}
     run-on-tasks-for: [action]

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -200,6 +200,7 @@ release-promotion:
             rebuild-kinds:
                 - build
                 - test
+                - addons-linter
                 - dep-signing
         promote:
             target-tasks-method: promote_xpi


### PR DESCRIPTION
Refs https://github.com/mozilla-extensions/xpi-manifest/issues/136

---

This is quite similar to https://github.com/mozilla-extensions/xpi-template/pull/31.

I removed `XPI_UPSTREAM_URLS` because that didn't seem to be used (and also I am not sure it works as expected). Let me know if that was a mistake.

Running `taskgraph full --json [--diff]` didn't output any errors and the diff looks good but I haven't been able to try this patch for real.

TODO:

- [x] pass `--privileged` to addons-linter when possible
- [x] specify an addons-linter version (likely 5.4.0) to prevent auto-updates (to avoid breaking the signing pipeline once https://github.com/mozilla/addons-linter/issues/4306 lands)