### PR TITLE
Add addons-linter kind as a prerequisite of release-signing kind

### DIFF
--- a/taskcluster/ci/release-signing/kind.yml
+++ b/taskcluster/ci/release-signing/kind.yml
@@ -2,11 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-
-loader: xpi_taskgraph.loader.single_dep:loader
+loader: xpi_taskgraph.loader.multi_dep:loader
 
 kind-dependencies:
     - build
+    - addons-linter
+
+primary-dependency: build
+group-by: xpi-name
 
 transforms:
     - xpi_taskgraph.transforms.signing:transforms

--- a/taskcluster/xpi_taskgraph/transforms/release_mark_as_shipped.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_mark_as_shipped.py
@@ -18,6 +18,8 @@ def make_task_description(config, jobs):
             and config.params.get("build_number")
         ):
             continue
+        if "primary-dependency" in job:
+            job.pop("primary-dependency")
         resolve_keyed_by(
             job, "scopes", item_name=job["name"], **{"level": config.params["level"]}
         )

--- a/taskcluster/xpi_taskgraph/transforms/signing.py
+++ b/taskcluster/xpi_taskgraph/transforms/signing.py
@@ -54,8 +54,10 @@ def define_signing_flags(config, tasks):
 @transforms.add
 def build_signing_task(config, tasks):
     for task in tasks:
-        dep = task["primary-dependency"]
-        task["dependencies"] = {"build": dep.label}
+        dep = task.pop("primary-dependency")
+        # When the `multi_dep` loader is used, it should already define the task dependencies.
+        if "dependencies" not in task:
+            task["dependencies"] = {"build": dep.label}
         if not dep.task["payload"]["env"]["ARTIFACT_PREFIX"].startswith("public"):
             scopes = task.setdefault("scopes", [])
             scopes.append(
@@ -85,7 +87,6 @@ def build_signing_task(config, tasks):
         ]
         task.setdefault("extra", {})["xpi-name"] = dep.task["extra"]["xpi-name"]
         task["extra"]["artifact_prefix"] = dep.task["payload"]["env"]["ARTIFACT_PREFIX"]
-        del task["primary-dependency"]
         yield task
 
 


### PR DESCRIPTION
Fixes https://github.com/mozilla-extensions/xpi-manifest/issues/169

---

~~The `group-by` didn't work as expected (see: https://github.com/mozilla-extensions/xpi-manifest/issues/169#issuecomment-1132830502) so I tried to not have a `group-by` essentially and at least the graph was loaded by `taskgraph`.~~

~~That being said, I wasn't able to review the actual graph for `release-signing` with `taskgraph`. I tried to supply a few parameters but that didn't change anything so I am not too sure if that's going to work :/~~

I added a new `group-by` to group tasks by `xpi_name`.

I fixed errors in the existing code since I actually triggered these error handling blocks.
