### PR TITLE
Use addons-linter v5.4.1 in linter tasks

### DIFF
--- a/taskcluster/ci/addons-linter/kind.yml
+++ b/taskcluster/ci/addons-linter/kind.yml
@@ -30,5 +30,5 @@ job-template:
         # This should be done by replacing `2` with `3` in the command below.
         command: >-
             curl -sSL --fail --retry 3 -o {xpi_file} "$XPI_URL" &&
-            npx -y addons-linter@5.4.0 --privileged --boring --disable-xpi-autoclose --max-manifest-version=2 {xpi_file}
+            npx -y addons-linter@5.4.1 --privileged --boring --disable-xpi-autoclose --max-manifest-version=2 {xpi_file}
     run-on-tasks-for: [action]


### PR DESCRIPTION
This is needed to fix a bug with the update_url check in some privileged extensions. See also: https://github.com/mozilla/addons-linter/releases/tag/5.4.1