### PR TITLE
Add tabtweak from MozillaOnline

### DIFF
--- a/manifests/tabtweak.yml
+++ b/manifests/tabtweak.yml
@@ -1,0 +1,9 @@
+---
+description: MozillaOnline Tab Tweak
+repo-prefix: tabtweak
+active: true
+private-repo: false
+artifacts:
+  - web-ext-artifacts/tabtweak.xpi
+addon-type: mozillaonline-privileged
+install-type: npm

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -75,6 +75,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/china-newtab
             default-ref: master
             type: git
+        tabtweak:
+            name: "MozillaOnline Tab Tweak"
+            project-regex: tabtweak$
+            default-repository: https://github.com/mozilla-extensions/tabtweak
+            default-ref: master
+            type: git
         webcompat:
             name: "Web Compat"
             project-regex: webcompat-addon$


### PR DESCRIPTION
This is necessary to update the extension in preparation for the `Services.jsm` removal.

[The repo](https://github.com/mozilla-extensions/tabtweak) was just transferred into mozilla-extensions, please also grant [the MozillaOnline team](https://github.com/orgs/mozilla-extensions/teams/mozillaonline/repositories) write access to it.

r?@escapewindow 

Thanks!