### PR TITLE
ADDONSOPS-233: Add new search-engine-usage-study-relaunch priviledged addon to xpi-manifest

### DIFF
--- a/manifests/search-engine-usage-study-relaunch.yml
+++ b/manifests/search-engine-usage-study-relaunch.yml
@@ -1,0 +1,9 @@
+description: Rally Search Engine Usage study extension relaunch
+repo-prefix: searchengineusagestudyrelaunch
+active: true
+private-repo: false
+branch: main
+artifacts:
+  - web-ext-artifacts/search_engine_usage_study.xpi
+addon-type: privileged
+install-type: npm

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -111,6 +111,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/search-engine-usage-study.git
             default-ref: release
             type: git
+        searchengineusagestudyrelaunch:
+            name: "Rally Search Engine Usage study extension relaunch"
+            project-regex: searchengineusagestudyrelaunch$
+            default-repository: https://github.com/mozilla-extensions/search-engine-usage-study-relaunch.git
+            default-ref: main
+            type: git
         firefoxtranslations:
             name: "Firefox Translations"
             project-regex: firefox-translations$


### PR DESCRIPTION
See [New Add-on Review Request: Search Engine Usage Study v1.2.0](https://mozilla-hub.atlassian.net/browse/ADDONSOPS-233)

We need to merge these changes to build the add-on in [mozilla-extensions/search-engine-usage-study-relaunch](https://github.com/mozilla-extensions/search-engine-usage-study-relaunch)