### PR TITLE
remote-settings-devtools should use "npm" (install-type)

### DIFF
--- a/manifests/remote-settings-devtools.yml
+++ b/manifests/remote-settings-devtools.yml
@@ -6,4 +6,4 @@ private-repo: false
 artifacts:
   - web-ext-artifacts/remote-settings-devtools.xpi
 addon-type: privileged
-install-type: yarn
+install-type: npm


### PR DESCRIPTION
The remote-settings-devtools repo uses `npm`, not `yarn`[^1]. That breaks the build apparently now, likely because `yarn` is more strict than `npm` when it comes to (node) engine versions.

[^1]: See: https://github.com/mozilla-extensions/remote-settings-devtools/blob/19a44e8f90b463db72a96960daf00975c23c400e/package-lock.json