### PR TITLE
Enable github releases for searchengine-devtools

### DIFF
--- a/manifests/searchengine-devtools.yml
+++ b/manifests/searchengine-devtools.yml
@@ -9,3 +9,4 @@ artifacts:
 addon-type: privileged
 install-type: npm
 additional-emails: ["standard8@mozilla.com", "dharvey@mozilla.com"]
+enable-github-release: true


### PR DESCRIPTION
Given that we add all searchengine-devtools releases to the github page, I think it'd be good to automate this.

I have added `@mozilla-extensions/bots` to the repository access.