### PR TITLE
Bug 1835689 - don't include cached tasks in existing_tasks for release promotion

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -192,6 +192,7 @@ release-promotion:
         build:
             target-tasks-method: build_xpi
             rebuild-kinds:
+                - docker-image
                 - build
                 - test
                 - addons-linter

--- a/taskcluster/xpi_taskgraph/release_promotion.py
+++ b/taskcluster/xpi_taskgraph/release_promotion.py
@@ -119,11 +119,11 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
     target_tasks_method = promotion_config["target-tasks-method"].format(
         project=parameters["project"]
     )
-    rebuild_kinds = input.get("rebuild_kinds") or promotion_config.get(
-        "rebuild-kinds", []
+    rebuild_kinds = input.get(
+        "rebuild_kinds", promotion_config.get("rebuild-kinds", [])
     )
-    do_not_optimize = input.get("do_not_optimize") or promotion_config.get(
-        "do-not-optimize", []
+    do_not_optimize = input.get(
+        "do_not_optimize", promotion_config.get("do-not-optimize", [])
     )
 
     # make parameters read-write

--- a/taskcluster/xpi_taskgraph/release_promotion.py
+++ b/taskcluster/xpi_taskgraph/release_promotion.py
@@ -82,6 +82,7 @@ def is_release_promotion_available(parameters):
                     "Optional: an array of kinds to ignore from the previous "
                     "graph(s)."
                 ),
+                "default": graph_config["release-promotion"].get("rebuild-kinds", []),
                 "items": {"type": "string"},
             },
             "previous_graph_ids": {


### PR DESCRIPTION
Release promotion reuses tasks generated by the on-push decision task,
to avoid duplicating work.  For cached tasks however, that means reusing
index lookups that can be out of date by the time relpro runs, and
requiring a new push to pick up rebuilt cached tasks.  By listing the
cached kinds in rebuild-kinds, we force new index lookups at release
promotion time, to pick up e.g. new docker images without an extra push.
