### PR TITLE
Enable Github releases for Remote Settings Devtools

### DIFF
--- a/manifests/remote-settings-devtools.yml
+++ b/manifests/remote-settings-devtools.yml
@@ -7,3 +7,4 @@ artifacts:
   - web-ext-artifacts/remote-settings-devtools.xpi
 addon-type: privileged
 install-type: npm
+enable-github-release: true


### PR DESCRIPTION
In slack, @abhn suggested to switch this flag to enable automatic publication of the XPI on the Github releases page.

Let me know if anything else is needed 🙏 

Thank you!

Ref https://github.com/mozilla-extensions/xpi-manifest/pull/165