### PR TITLE
fix: point root dir to /taskcluster in 'github_release' transforms

### DIFF
--- a/taskcluster/xpi_taskgraph/transforms/release_github.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_github.py
@@ -13,8 +13,7 @@ from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by
 from xpi_taskgraph.xpi_manifest import get_manifest
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-ROOT = os.path.join(BASE_DIR, "ci")
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))  # /taskcluster
 
 transforms = TransformSequence()
 


### PR DESCRIPTION
This was missed as part of the Taskgraph v7 update.