### PR TITLE
ci: don't schedule Github release tasks in staging environments

### DIFF
--- a/taskcluster/xpi_taskgraph/transforms/release_github.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_github.py
@@ -35,6 +35,8 @@ def build_worker_definition(config, tasks):
             config.params.get("version")
             and config.params.get("xpi_name")
             and config.params.get("build_number")
+            # Don't create Github releases if we're using a fork of `xpi-manifest`
+            and config.params["project"] == "xpi-manifest"
         ):
             continue
 


### PR DESCRIPTION
These tasks create actual Github releases on the individual extension repos. When testing against `staging-xpi-manifest` or other forks, we rightly don't have scopes to create releases there.

To allow these stage releases to proceed without scope errors, let's filter these tasks out whenever we aren't testing against `xpi-manifest` proper.