### PR TITLE
Allow test@tests.mozilla.org ID

### DIFF
--- a/taskcluster/docker/node/build.py
+++ b/taskcluster/docker/node/build.py
@@ -26,6 +26,8 @@ ID_ALLOWLIST = (
     "@mozillafoundation.org",
     # A temporary special case for aboutsync, which has a "legacy" ID.
     "aboutsync@mhammond.github.com",
+    # Allow https://github.com/mozilla-extensions/privileged-test-xpi.
+    "test@tests.mozilla.org",
 )
 
 


### PR DESCRIPTION
This is needed to sign the privileged _test_ extension for mozilla-central.