### PR TITLE
Add Devtools ADB extension

### DIFF
--- a/manifests/devtools-adb-extension-linux.yml
+++ b/manifests/devtools-adb-extension-linux.yml
@@ -1,0 +1,11 @@
+description: Devtools ADB Extension for linux
+repo-prefix: devtoolsadbextension
+active: true
+private-repo: false
+branch: xpi-template
+directory: extension/linux/
+artifacts:
+  - adb-extension-linux.xpi
+addon-type: privileged
+install-type: npm
+enable-github-release: true

--- a/manifests/devtools-adb-extension-linux64.yml
+++ b/manifests/devtools-adb-extension-linux64.yml
@@ -1,0 +1,11 @@
+description: Devtools ADB Extension for linux64
+repo-prefix: devtoolsadbextension
+active: true
+private-repo: false
+branch: xpi-template
+directory: extension/linux64/
+artifacts:
+  - adb-extension-linux64.xpi
+addon-type: privileged
+install-type: npm
+enable-github-release: true

--- a/manifests/devtools-adb-extension-mac64.yml
+++ b/manifests/devtools-adb-extension-mac64.yml
@@ -1,0 +1,11 @@
+description: Devtools ADB Extension for mac64
+repo-prefix: devtoolsadbextension
+active: true
+private-repo: false
+branch: xpi-template
+directory: extension/mac64/
+artifacts:
+  - adb-extension-mac64.xpi
+addon-type: privileged
+install-type: npm
+enable-github-release: true

--- a/manifests/devtools-adb-extension-win32.yml
+++ b/manifests/devtools-adb-extension-win32.yml
@@ -1,0 +1,11 @@
+description: Devtools ADB Extension for win32
+repo-prefix: devtoolsadbextension
+active: true
+private-repo: false
+branch: xpi-template
+directory: extension/win32/
+artifacts:
+  - adb-extension-win32.xpi
+addon-type: privileged
+install-type: npm
+enable-github-release: true

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -141,6 +141,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/privileged-test-xpi
             default-ref: main
             type: git
+        devtoolsadbextension:
+            name: "Devtools ADB Extension"
+            project-regex: devtools-adb-extension$
+            default-repository: https://github.com/mozilla-extensions/devtools-adb-extension
+            default-ref: master
+            type: git
 
 workers:
     aliases:


### PR DESCRIPTION
This PR adds the ADB privileged extension, see: https://github.com/mozilla-extensions/devtools-adb-extension.

In the future, it'd be great to push the signed extensions to the FTP at https://ftp.mozilla.org/pub/labs/devtools/adb-extension/.