### PR TITLE
Add fingerprinting-protection-debugger.xpi

### DIFF
--- a/manifests/fingerprinting-protection-debugger.yml
+++ b/manifests/fingerprinting-protection-debugger.yml
@@ -1,0 +1,13 @@
+---
+description: Fingerprinting Protection Debugger Addon
+repo-prefix: fingerprinting-protection-debugger
+active: true
+private-repo: false
+additional-emails: ["fkilic@mozilla.com"]
+branch: main
+# list of strings: A list of paths of xpis generated. Required.
+artifacts:
+  - fingerprinting-protection-debugger.xpi
+addon-type: privileged
+install-type: npm
+enable-github-release: true

--- a/manifests/fingerprinting-protection-debugger.yml
+++ b/manifests/fingerprinting-protection-debugger.yml
@@ -3,7 +3,7 @@ description: Fingerprinting Protection Debugger Addon
 repo-prefix: fingerprinting-protection-debugger
 active: true
 private-repo: false
-additional-emails: ["fkilic@mozilla.com"]
+additional-emails: ["fkilic@mozilla.com", "fbraun@mozilla.com", "tom@mozilla.com", "tihuang@mozilla.com"]
 branch: main
 # list of strings: A list of paths of xpis generated. Required.
 artifacts:

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -123,7 +123,7 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/privileged-test-xpi
             default-ref: main
             type: git
-        fingerprinting-protection-debugger:
+        fingerprintingprotectiondebugger:
             name: "Fingerprinting Protection Debugger"
             project-regex: fingerprinting-protection-debugger$
             default-repository: https://github.com/mozilla-extensions/fingerprinting-protection-debugger

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -123,6 +123,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/privileged-test-xpi
             default-ref: main
             type: git
+        fingerprinting-protection-debugger:
+            name: "Fingerprinting Protection Debugger"
+            project-regex: fingerprinting-protection-debugger$
+            default-repository: https://github.com/mozilla-extensions/fingerprinting-protection-debugger
+            default-ref: main
+            type: git
 
 workers:
     aliases:


### PR DESCRIPTION
Hello,

I'm following [Adding a new xpi](https://github.com/mozilla-extensions/xpi-manifest/blob/main/docs/adding-a-new-xpi.md) steps for [mozilla-extensions/fingerprinting-protection-debugger](https://github.com/mozilla-extensions/fingerprinting-protection-debugger), and this should be the required step for [Enabling releases](https://github.com/mozilla-extensions/xpi-manifest/blob/main/docs/adding-a-new-xpi.md#enabling-releases), but if anything is missing, please do let me know, I can update accordingly.

Thank you!