### PR TITLE
Remove /ci and .ci from taskcluster.ci amd taskcluster/ci

### DIFF
--- a/docs/adding-a-new-xpi.md
+++ b/docs/adding-a-new-xpi.md
@@ -129,7 +129,7 @@ Once Taskcluster CI automation is enabled, you will see a decision task (and rel
 
 To enable releases for your new repo, go to the [`xpi-manifest`](https://github.com/mozilla-extensions/xpi-manifest) repository.
 
-1. Add the source repository to [`taskgraph.repositories`](https://github.com/mozilla-extensions/xpi-manifest/blob/main/taskcluster/ci/config.yml#L8-L23) in the `xpi-manifest` repository's [taskcluster/ci/config.yml](../taskcluster/ci/config.yml). If this is the first xpi in your source repo, you need to add it. Public repos will look like this:
+1. Add the source repository to [`taskgraph.repositories`](https://github.com/mozilla-extensions/xpi-manifest/blob/main/taskcluster/config.yml#L8-L23) in the `xpi-manifest` repository's [taskcluster/config.yml](../taskcluster/config.yml). If this is the first xpi in your source repo, you need to add it. Public repos will look like this:
 
     ```yaml
         normandydevtools:  # This needs to not have any _ or -
@@ -155,7 +155,7 @@ To enable releases for your new repo, go to the [`xpi-manifest`](https://github.
         type: git
     ```
 
-2. Add the xpi to the [xpi manifest directory](../manifests/). Copy [manifests/template-example.yml.template](https://github.com/mozilla-extensions/xpi-manifest/blob/main/manifests/template-example.yml.template) to `manifests/{name}.yml`, where `{name}` is the name of your addon. Then edit: the `repo-prefix` will refer to the repository key name under `taskgraph.repositories` in the `xpi-manifest` repository's `taskcluster/ci/config.yml`.
+2. Add the xpi to the [xpi manifest directory](../manifests/). Copy [manifests/template-example.yml.template](https://github.com/mozilla-extensions/xpi-manifest/blob/main/manifests/template-example.yml.template) to `manifests/{name}.yml`, where `{name}` is the name of your addon. Then edit: the `repo-prefix` will refer to the repository key name under `taskgraph.repositories` in the `xpi-manifest` repository's `taskcluster/config.yml`.
 
 The PR should run sanity checks on pull request and push; make sure the decision task and the build for your addon goes green.
 
@@ -168,7 +168,7 @@ After you are satisfied with your testing, see [Releasing a XPI](releasing-a-xpi
 ## custom tooling needs
 If you need extra npm's installed or a different version of node, it will be documented here.  What we currently have available is a way to specify a custom docker image:
 
- in `package.json` you can specify a `docker-image` ([existing choices](https://github.com/mozilla-extensions/xpi-manifest/blob/main/taskcluster/ci/docker-image/kind.yml) or add a new one):
+ in `package.json` you can specify a `docker-image` ([existing choices](https://github.com/mozilla-extensions/xpi-manifest/blob/main/taskcluster/kinds/docker-image/kind.yml) or add a new one):
 ```
 {
     ...

--- a/docs/releasing-a-xpi.md
+++ b/docs/releasing-a-xpi.md
@@ -26,7 +26,7 @@ Just like the Build and Promote phases, there are also `release-notify-started` 
 
 ## Configuring email notifications
 
-These are configured per addon-type (privileged webextension vs system addon) and per phase (build or promote), in the `xpi-manifest` repository's [`taskcluster/ci/config.yml`](../taskcluster/ci/config.yml), under `release-promotion.notifications`.
+These are configured per addon-type (privileged webextension vs system addon) and per phase (build or promote), in the `xpi-manifest` repository's [`taskcluster/config.yml`](../taskcluster/config.yml), under `release-promotion.notifications`.
 
 LDAP-controlled mail lists are preferred over individual emails. You may want to add a +comment (e.g. `email+system-addon-release-builds@m.c` for easier filtering.
 

--- a/manifests/staging-public.yml
+++ b/manifests/staging-public.yml
@@ -2,7 +2,7 @@
 # string: Longer description of the xpi, for humans. Optional.
 description: Test template repo with on-push/on-pr automation
 # Alphanumeric string that corresponds to a key in
-# taskcluster.ci.config.taskgraph.repositories . Required.
+# taskcluster.config.taskgraph.repositories . Required.
 repo-prefix: stagingpublic
 # boolean: enable releases of this xpi or disable them. Optional.
 #          Defaults to `true`.
@@ -17,7 +17,7 @@ additional-emails: []
 #            root of the repository.
 directory: one
 # string: branch name. Optional. Defaults to the default-ref in
-#         taskcluster.ci.config.taskgraph.repositories .
+#         taskcluster.config.taskgraph.repositories .
 branch: main
 # list of strings: A list of paths of xpis generated. Required.
 artifacts:

--- a/manifests/template-example.yml.template
+++ b/manifests/template-example.yml.template
@@ -2,7 +2,7 @@
 # string: Longer description of the xpi, for humans. Optional.
 description: Test template repo with on-push/on-pr automation
 # Alphanumeric string that corresponds to a key in
-# taskcluster.ci.config.taskgraph.repositories . Required.
+# taskcluster.config.taskgraph.repositories . Required.
 repo-prefix: stagingpublic
 # boolean: enable releases of this xpi or disable them. Optional.
 #          Defaults to `true`.
@@ -20,7 +20,7 @@ directory: one
 #         in taskcluster/kinds/[build|test]/kind.yml .
 docker-image: node-16
 # string: branch name. Optional. Defaults to the default-ref in
-#         taskcluster.ci.config.taskgraph.repositories .
+#         taskcluster.config.taskgraph.repositories .
 branch: master
 # list of strings: A list of paths of xpis generated. Required.
 artifacts:

--- a/manifests/template-example.yml.template
+++ b/manifests/template-example.yml.template
@@ -17,7 +17,7 @@ additional-emails: []
 #            root of the repository.
 directory: one
 # string: docker-image. Optional. Defaults to node-16 as found
-#         in taskcluster/ci/[build|test]/kind.yml .
+#         in taskcluster/kinds/[build|test]/kind.yml .
 docker-image: node-16
 # string: branch name. Optional. Defaults to the default-ref in
 #         taskcluster.ci.config.taskgraph.repositories .


### PR DESCRIPTION
I was working on #223, and realized some broken links. It seems taskcluster/ci was moved to taskcluster/, so this should hopefully fix it. Thank you!