### PR TITLE
linter: use node-20 docker image

### DIFF
--- a/taskcluster/kinds/addons-linter/kind.yml
+++ b/taskcluster/kinds/addons-linter/kind.yml
@@ -19,7 +19,7 @@ task-template:
     only-for-formats: ["privileged"]
     worker:
         docker-image:
-            in-tree: node-16
+            in-tree: node-20
         max-run-time: 7200
     run:
         using: run-task


### PR DESCRIPTION
node 16 is EOL, and no longer supported by the addons linter.

This matches the change in
https://github.com/mozilla-extensions/xpi-template/pull/44