### PR TITLE
fix: restrict taskcluster tasks to main branch

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,8 +5,9 @@ policy:
     pullRequests: collaborators
 tasks:
     - $if: >
-          tasks_for in ["action", "cron", "github-push"]
+          tasks_for in ["action", "cron"]
           || (tasks_for == "github-pull-request" && event.action in ["opened", "reopened", "synchronize"])
+          || (tasks_for == "github-push" && event.ref == "refs/heads/main")
       then:
           $let:
             trustDomain: xpi


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1907217 we're moving away from granting scopes to all branches of a repository. This means that any branches that need scopes should be specified explicitly in https://github.com/mozilla-releng/fxci-config/blob/main/projects.yml.

To avoid confusion, I'm trying to sync up branches that run tasks with branches in projects.yml. As far as I can tell, main is the only one that actually ought to run tasks in this repository. (We've used other branches before, but it's not clear to me that we actually need to. We can always add branches or even a prefix later if needed.)