### PR TITLE
Enable GitHub Releases for the WebCompat Interventions addon.

### DIFF
--- a/manifests/webcompat-release-hotfix.yml
+++ b/manifests/webcompat-release-hotfix.yml
@@ -7,3 +7,4 @@ artifacts:
   - web-ext-artifacts/webcompat.xpi
 addon-type: system
 install-type: npm
+enable-github-release: true

--- a/manifests/webcompat.yml
+++ b/manifests/webcompat.yml
@@ -7,3 +7,4 @@ artifacts:
   - web-ext-artifacts/webcompat.xpi
 addon-type: system
 install-type: npm
+enable-github-release: true


### PR DESCRIPTION
This should allow that we automatically have a tag, a GitHub release, and attached artifacts in our GitHub repo.