### PR TITLE
feat: add stage_ and gcp_prod_ signing formats

### DIFF
--- a/taskcluster/xpi_taskgraph/transforms/signing.py
+++ b/taskcluster/xpi_taskgraph/transforms/signing.py
@@ -13,7 +13,7 @@ from taskgraph.util.schema import resolve_keyed_by
 
 transforms = TransformSequence()
 
-KNOWN_FORMATS = ("privileged_webextension", "system_addon")
+KNOWN_FORMATS = ("privileged_webextension", "system_addon", "stage_privileged_webextension", "stage_system_addon", "gcp_prod_privileged_webextension", "gcp_prod_system_addon")
 
 
 @transforms.add


### PR DESCRIPTION
This in support of the Autograph GCP migration. These new formats allow us to opt into signing against the gcp prod and gcp stage autograph environments.