### PR TITLE
bug 1942364: switch to autograph gcp production for signing

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -185,11 +185,11 @@ scriptworker:
     scope-prefix: project:xpi:releng
     signing-format:
         by-xpi-type:
-            mozillaonline-privileged: privileged_webextension
-            privileged: privileged_webextension
-            system: system_addon
+            mozillaonline-privileged: gcp_prod_privileged_webextension
+            privileged: gcp_prod_privileged_webextension
+            system: gcp_prod_system_addon
             # normandy-privileged is deprecated
-            normandy-privileged: privileged_webextension
+            normandy-privileged: gcp_prod_privileged_webextension
 
 release-promotion:
     flavors:

--- a/taskcluster/xpi_taskgraph/transforms/signing.py
+++ b/taskcluster/xpi_taskgraph/transforms/signing.py
@@ -6,14 +6,20 @@ Apply some defaults and minor modifications to the tasks defined in the build
 kind.
 """
 
-
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.keyed_by import evaluate_keyed_by
 from taskgraph.util.schema import resolve_keyed_by
 
 transforms = TransformSequence()
 
-KNOWN_FORMATS = ("privileged_webextension", "system_addon", "stage_privileged_webextension", "stage_system_addon", "gcp_prod_privileged_webextension", "gcp_prod_system_addon")
+KNOWN_FORMATS = (
+    "privileged_webextension",
+    "system_addon",
+    "stage_privileged_webextension",
+    "stage_system_addon",
+    "gcp_prod_privileged_webextension",
+    "gcp_prod_system_addon",
+)
 
 
 @transforms.add


### PR DESCRIPTION
This needs to wait for https://github.com/mozilla-releng/scriptworker-scripts/pull/1123 to be deployed before it can be merged.