### PR TITLE
chore: drop now unused signing formats

### DIFF
--- a/taskcluster/xpi_taskgraph/transforms/signing.py
+++ b/taskcluster/xpi_taskgraph/transforms/signing.py
@@ -13,8 +13,6 @@ from taskgraph.util.schema import resolve_keyed_by
 transforms = TransformSequence()
 
 KNOWN_FORMATS = (
-    "privileged_webextension",
-    "system_addon",
     "stage_privileged_webextension",
     "stage_system_addon",
     "gcp_prod_privileged_webextension",


### PR DESCRIPTION
These used to use AWS Autograph, which is going away very soon.