### PR TITLE
fix: duplicate notify routes

### DIFF
--- a/taskcluster/xpi_taskgraph/transforms/release_notifications.py
+++ b/taskcluster/xpi_taskgraph/transforms/release_notifications.py
@@ -47,7 +47,7 @@ def add_notifications(config, tasks):
         )
         if not emails:
             continue
-        emails = (
+        emails = set(
             emails + additional_shipit_emails + xpi_config.get("additional-emails", [])
         )
         notifications = evaluate_keyed_by(
@@ -60,7 +60,7 @@ def add_notifications(config, tasks):
         # We only send mail on success to avoid messages like 'blah is in the
         # candidates dir' when cancelling graphs, dummy task failure, etc
         task.setdefault("routes", []).extend(
-            [f"notify.email.{email}.on-completed" for email in emails]
+            sorted(f"notify.email.{email}.on-completed" for email in emails)
         )
 
         task.setdefault("extra", {}).update({"notify": {"email": {"subject": subject}}})


### PR DESCRIPTION
If a user signs off on a release, their e-mail automatically gets added to the notify routes. If their e-mail is there for another reason (like it's in the 'additional-email' key of the extension config), then it gets added again. This causes a schema validation error in Taskcluster.

This patch converts the e-mails from a list to set to get rid of duplicates.

Note: Taskgraph should also detect and fail on duplicate routes.