### PR TITLE
ci: stop creating test tasks for newtab + webcompat

### DIFF
--- a/manifests/newtab.yml
+++ b/manifests/newtab.yml
@@ -11,3 +11,4 @@ artifacts:
 addon-type: system
 install-type: mach
 enable-github-release: False
+enable-test: False

--- a/manifests/webcompat.yml
+++ b/manifests/webcompat.yml
@@ -9,3 +9,4 @@ artifacts:
 addon-type: system
 install-type: mach
 enable-github-release: false
+enable-test: false

--- a/taskcluster/xpi_taskgraph/transforms/post_build.py
+++ b/taskcluster/xpi_taskgraph/transforms/post_build.py
@@ -24,9 +24,14 @@ def test_tasks_from_manifest(config, tasks):
         xpi_name = dep.task["extra"]["xpi-name"]
         xpi_revision = config.params.get("xpi_revision")
         task.setdefault("extra", {})["xpi-name"] = xpi_name
+
         xpi_config = manifest[xpi_name]
         if not xpi_config.get("active"):
             continue
+
+        if config.kind == "test" and not xpi_config.get("enable-test", True):
+            continue
+
         env = task.setdefault("worker", {}).setdefault("env", {})
         run = task.setdefault("run", {})
         checkout = run.setdefault("checkout", {})

--- a/taskcluster/xpi_taskgraph/xpi_manifest.py
+++ b/taskcluster/xpi_taskgraph/xpi_manifest.py
@@ -37,6 +37,7 @@ base_schema = Schema(
         ),
         Optional("install-type"): Any("mach", "npm", "yarn"),
         Optional("enable-github-release"): bool,
+        Optional("enable-test"): bool,
         Optional("release-tag"): str,
         Optional("release-name"): str,
     }


### PR DESCRIPTION
These tasks currently clone the firefox repo and then exit without running anything. They also block the release pipeline.

Let's just never create them in the first place.