### PR TITLE
Update data-leak-blocker directory (bug 1988533)

### DIFF
--- a/manifests/data-leak-blocker.yml
+++ b/manifests/data-leak-blocker.yml
@@ -3,7 +3,7 @@ repo-prefix: dataleakblocker
 active: true
 private-repo: false
 branch: main
-directory: browser/extensions/data-leak-blocker
+directory: browser/extensions/data-leak-blocker/extension
 artifacts:
   - web-ext-artifacts/data-leak-blocker.xpi
 addon-type: system


### PR DESCRIPTION
shipit uses this directory to look for the addon's manifest.json.